### PR TITLE
Supported reloading on backend with Docker Compose Watch

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,19 +1,14 @@
 FROM golang:1.23-alpine
 
-# Sets the container's working directory to /app
+
+# Set the working directory (this is /backend in Arenius)
 WORKDIR /app
 
-# Copy mod and sum files for efficiency/caching
+# Copy only go.mod and go.sum first (to cache dependencies)
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Copies the contents of this directory (backend and subdirs) to /app/backend/cmd in the container
-COPY . ./backend
+# Copy the entire project
+COPY . .
 
-WORKDIR /app/backend/cmd
-
-RUN go build -o main .
-
-EXPOSE 8080
-
-CMD ["./main"]
+WORKDIR /app/cmd

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,14 +9,22 @@ services:
     networks:
       - app-network
 
+
   backend:
     build:
       context: ./backend
     ports:
       - "8080:8080"
+    command: go run main.go
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./backend
+          target: /app
     networks:
       - app-network
     container_name: backend
+
 
 networks:
   app-network:


### PR DESCRIPTION
## Motivation
Right now developing with Docker is a bit annoying--my bad--as we have to re-build each time we make changes. I also did not set a precedent of whether to use Docker Compose or run just the frontend or backend when developing.

I wanted to make it so we could have a similar experience to using Nix where saving changes would trigger a rebuild. I thought of a few approaches:
If using compose to develop:
- Volume mount /backend:/app/backend, then manually execute in a shell inside the container 'go run main.go'
- Volume mount and use a live reloading Go library like [fresh](https://github.com/gravityblast/fresh)

The first approach is annoying and the second approach is shortsighted and won't work for frontend.

Then I found [Docker Compose Watch](https://docs.docker.com/compose/how-tos/file-watch/) which allows for Docker to watch for changes in specified directories and then sync and restart. I don't think watch can work while also volume mounting, but I don't think it makes sense to do that anyways.

## Changes
docker-compose.yaml:
```
backend:
    build:
      context: ./backend
    ports:
      - "8080:8080"
    **command: go run main.go
    develop:
      watch:
        - action: sync+restart
          path: ./backend
          target: /app**
    networks:
      - app-network
    container_name: backend

```
The bolded block allows for compose to start the backend and then sync file changes + restart the container on changes.
/backend/Dockerfile:
```
FROM golang:1.23-alpine


# Set the working directory (this is /backend in Arenius)
WORKDIR /app

# Copy only go.mod and go.sum first (to cache dependencies)
COPY go.mod go.sum ./
RUN go mod download

# Copy the entire project
COPY . .

WORKDIR /app/cmd

```
The dockerfile has been condensed and running the image does not run the backend, development should be done through compose.

## To Develop
```
cd backend
docker compose up --build
# press 'w' to enable Watch !!
```
Any changes made in backend will cause a rebuild of the backend service.

## Before Enabling Watch
![image](https://github.com/user-attachments/assets/41dd16f2-e7cd-4200-b804-e31004709300)

## After Enabling Watch and Changing in Backend
![image](https://github.com/user-attachments/assets/939b8fec-0ffc-4ccf-ae64-f4040e652caa)
