### PR TITLE
Be 25 line item get filtering

### DIFF
--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -46,3 +46,9 @@ type CreateLineItemRequest struct {
 	Scope          *int     `json:"scope,omitempty"`
 	CO2Unit        *string  `json:"co2_unit,omitempty"`
 }
+
+type GetLineItemsRequest struct {
+	CompanyID            *string    `json:"company_id"`
+	Date                 *time.Time `json:"date"`
+	ReconciliationStatus *bool      `json:"reconciliation_status"`
+}

--- a/backend/internal/service/handler/lineitem/get_line_items.go
+++ b/backend/internal/service/handler/lineitem/get_line_items.go
@@ -2,6 +2,7 @@ package lineitem
 
 import (
 	"arenius/internal/errs"
+	"arenius/internal/models"
 	"arenius/internal/service/utils"
 	"fmt"
 
@@ -18,7 +19,12 @@ func (h *Handler) GetLineItems(c *fiber.Ctx) error {
 		return errs.BadRequest(fmt.Sprint("invalid pagination values: ", errors))
 	}
 
-	lineItems, err := h.lineItemRepository.GetLineItems(c.Context(), pagination)
+	var filterParams models.GetLineItemsRequest
+	if err := c.BodyParser(&filterParams); err != nil {
+		return errs.BadRequest(fmt.Sprintf("error parsing request body: %v", err))
+	}
+
+	lineItems, err := h.lineItemRepository.GetLineItems(c.Context(), pagination, filterParams)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -17,15 +17,43 @@ type LineItemRepository struct {
 	db *pgxpool.Pool
 }
 
-func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.Pagination) ([]models.LineItem, error) {
+func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItem, error) {
+	filterQuery := "WHERE 1=1"
+
+	if filterParams.ReconciliationStatus != nil {
+		if *filterParams.ReconciliationStatus {
+			filterQuery += " AND line_item.emission_factor IS NOT NULL"
+		} else {
+			filterQuery += " AND line_item.emission_factor IS NULL"
+		}
+	}
+
+	filterColumns := []string{}
+	filterArgs := []interface{}{}
+
+	if filterParams.CompanyID != nil {
+		filterColumns = append(filterColumns, "company_id")
+		filterArgs = append(filterArgs, *filterParams.CompanyID)
+	}
+	if filterParams.Date != nil {
+		filterColumns = append(filterColumns, "date")
+		filterArgs = append(filterArgs, filterParams.Date.UTC())
+	}
+
+	for i := 0; i < len(filterColumns); i++ {
+		filterQuery += fmt.Sprintf(" AND %s=$%d", filterColumns[i], i+3)
+	}
+
 	query := `
 		SELECT id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor, amount, unit, co2, co2_unit, scope
-		FROM line_item
-		ORDER BY date
-		LIMIT $1 OFFSET $2`
+		FROM line_item ` + filterQuery +
+		` ORDER BY date
+		LIMIT $1 OFFSET $2 `
 
-	offset := pagination.GetOffset()
-	rows, err := r.db.Query(ctx, query, pagination.Limit, offset)
+	fmt.Println(query)
+
+	queryArgs := append([]interface{}{pagination.Limit, pagination.GetOffset()}, filterArgs...)
+	rows, err := r.db.Query(ctx, query, queryArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +62,7 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 	var lineItems []models.LineItem
 	for rows.Next() {
 		var lineItem models.LineItem
-		if err := rows.Scan(&lineItem.ID, &lineItem.XeroLineItemID, &lineItem.Description, &lineItem.Quantity, &lineItem.UnitAmount, &lineItem.CompanyID, &lineItem.ContactID, &lineItem.Date, &lineItem.CurrencyCode, &lineItem.EmissionFactor, &lineItem.Amount, &lineItem.Unit, &lineItem.CO2, &lineItem.Scope, &lineItem.CO2Unit); err != nil {
+		if err := rows.Scan(&lineItem.ID, &lineItem.XeroLineItemID, &lineItem.Description, &lineItem.Quantity, &lineItem.UnitAmount, &lineItem.CompanyID, &lineItem.ContactID, &lineItem.Date, &lineItem.CurrencyCode, &lineItem.EmissionFactor, &lineItem.Amount, &lineItem.Unit, &lineItem.CO2, &lineItem.CO2Unit, &lineItem.Scope); err != nil {
 			return nil, err
 		}
 		lineItems = append(lineItems, lineItem)
@@ -54,7 +82,7 @@ func (r *LineItemRepository) ReconcileLineItem(ctx context.Context, lineItemId i
 		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor, amount, unit, co2, co2_unit, scope
 	`
 	var lineItem models.LineItem
-	err := r.db.QueryRow(ctx, query, req.EmissionsFactor, req.Amount, req.Unit, lineItemId).Scan(&lineItem.ID, &lineItem.XeroLineItemID, &lineItem.Description, &lineItem.Quantity, &lineItem.UnitAmount, &lineItem.CompanyID, &lineItem.ContactID, &lineItem.Date, &lineItem.CurrencyCode, &lineItem.EmissionFactor, &lineItem.Amount, &lineItem.Unit, &lineItem.CO2, &lineItem.Scope, &lineItem.CO2Unit)
+	err := r.db.QueryRow(ctx, query, req.EmissionsFactor, req.Amount, req.Unit, lineItemId).Scan(&lineItem.ID, &lineItem.XeroLineItemID, &lineItem.Description, &lineItem.Quantity, &lineItem.UnitAmount, &lineItem.CompanyID, &lineItem.ContactID, &lineItem.Date, &lineItem.CurrencyCode, &lineItem.EmissionFactor, &lineItem.Amount, &lineItem.Unit, &lineItem.CO2, &lineItem.CO2Unit, &lineItem.Scope)
 
 	if err != nil {
 		return nil, fmt.Errorf("error querying database: %w", err)
@@ -88,8 +116,8 @@ func (r *LineItemRepository) AddLineItemEmissions(ctx context.Context, req model
 		&lineItem.Amount,
 		&lineItem.Unit,
 		&lineItem.CO2,
-		&lineItem.Scope,
-		&lineItem.CO2Unit)
+		&lineItem.CO2Unit,
+		&lineItem.Scope)
 
 	if err != nil {
 		return nil, fmt.Errorf("error querying database: %w", err)
@@ -114,7 +142,7 @@ func (r *LineItemRepository) CreateLineItem(ctx context.Context, req models.Crea
 		INSERT INTO line_item
 		(` + strings.Join(columns, ", ") + `)
 		VALUES (` + strings.Join(numInputs, ", ") + `)
-		RETURNING *;
+		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor, amount, unit, co2, co2_unit, scope;
 	`
 	var lineItem models.LineItem
 	err := r.db.QueryRow(ctx, query, queryArgs...).Scan(
@@ -131,8 +159,8 @@ func (r *LineItemRepository) CreateLineItem(ctx context.Context, req models.Crea
 		&lineItem.Amount,
 		&lineItem.Unit,
 		&lineItem.CO2,
-		&lineItem.Scope,
-		&lineItem.CO2Unit)
+		&lineItem.CO2Unit,
+		&lineItem.Scope)
 
 	if err != nil {
 		return nil, fmt.Errorf("error querying database: %w", err)

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -50,8 +50,6 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 		` ORDER BY date
 		LIMIT $1 OFFSET $2 `
 
-	fmt.Println(query)
-
 	queryArgs := append([]interface{}{pagination.Limit, pagination.GetOffset()}, filterArgs...)
 	rows, err := r.db.Query(ctx, query, queryArgs...)
 	if err != nil {

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -15,7 +15,7 @@ type TransactionRepository interface {
 }
 
 type LineItemRepository interface {
-	GetLineItems(ctx context.Context, pagination utils.Pagination) ([]models.LineItem, error)
+	GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItem, error)
 	ReconcileLineItem(ctx context.Context, lineItemId int, req models.ReconcileLineItemRequest) (*models.LineItem, error)
 	AddLineItemEmissions(ctx context.Context, req models.LineItemEmissionsRequest) (*models.LineItem, error)
 	CreateLineItem(ctx context.Context, req models.CreateLineItemRequest) (*models.LineItem, error)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[BE-25](https://github.com/GenerateNU/arenius/issues/25)

<!--- Describe your changes at a high-level -->

Added filtering to line-item GET with the optional filter parameters described below. Also I realized in my POST pr I messed up some of the other endpoints so I reverted those changes (swapping scope and CO2Unit). 

## How Has This Been Tested?

#### Backend PRs
<!--- Please include a URL for the success case. Treat this as a reference for future developers - people should be able to use this to successfully use your endpoint later on! -->
Postman URL here:

Body parameters (if required):
All 3 are optional. If ReconciliationStatus is true, filters to only line-items with non-null EmissionFactor, and filters to null EmissionFactors when false.
```
type GetLineItemsRequest struct {
	CompanyID            *string    `json:"company_id"`
	Date                 *time.Time `json:"date"`
	ReconciliationStatus *bool      `json:"reconciliation_status"`
}
```
Postman/Supabase screenshots:
![Screenshot 2025-01-23 185144](https://github.com/user-attachments/assets/aea53a4f-c9d8-4058-9f89-0d599d593c86)
![Screenshot 2025-01-23 185157](https://github.com/user-attachments/assets/bfc4e6db-7d68-42d8-909d-abcccea4da12)
![Screenshot 2025-01-23 185319](https://github.com/user-attachments/assets/1348446d-28b2-4bf5-9733-8a5dcc0f21df)
![Screenshot 2025-01-23 190310](https://github.com/user-attachments/assets/4a13c415-abbb-4096-8779-aa3b8e9518fb)
![Screenshot 2025-01-23 190428](https://github.com/user-attachments/assets/218fdbe1-5ce9-4f72-bb27-96772e4063b4)


#### Frontend PRs
Page route (and description of to get to this flow if necessary):

Screenshots/screen recording:


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend

Closes #25 
