### PR TITLE
Connecting Tenant ID for Xero Auth & GET Request for Bank Transactions

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.2
 	github.com/joho/godotenv v1.5.1
 	github.com/sethvargo/go-envconfig v1.1.0
+	golang.org/x/oauth2 v0.25.0
 )
 
 require (

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -52,6 +52,8 @@ github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVS
 github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
+golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -16,7 +16,7 @@ func GetBankTransactions() ([]map[string]interface{}, error) {
 
 	if accessToken == "" || tenantId == "" || url == "" {
 		fmt.Printf("Examine env values: accessToken=%s, tenantId=%s, url=%s\n", accessToken, tenantId, url)
-		return nil, errs.BadRequest(fmt.Sprint("missing env variables"))
+		return nil, fmt.Errorf("missing required environment variables")
 	}
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -1,0 +1,65 @@
+package xero
+
+import (
+	"arenius/internal/errs"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func GetBankTransactions() ([]map[string]interface{}, error) {
+	accessToken := os.Getenv("ACCESS_TOKEN")
+	tenantId := os.Getenv("TENANT_ID")
+	url := os.Getenv("TRANSACTIONS_URL")
+
+	if accessToken == "" || tenantId == "" || url == "" {
+		fmt.Printf("Examine env values: accessToken=%s, tenantId=%s, url=%s\n", accessToken, tenantId, url)
+		return nil, errs.BadRequest(fmt.Sprint("missing env variables"))
+	}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errs.BadRequest(fmt.Sprint("invalid request: ", err))
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Xero-tenant-id", tenantId)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errs.BadRequest(fmt.Sprint("error handling request: ", err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errs.BadRequest(fmt.Sprint("response status unsuccessful: ", err))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errs.BadRequest(fmt.Sprint("unable to read response body: ", err))
+	}
+
+	var response map[string]interface{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, errs.BadRequest(fmt.Sprint("unable to unpack reponse: ", err))
+	}
+
+	transactions, ok := response["BankTransactions"].([]interface{})
+	if !ok {
+		return nil, errs.BadRequest(fmt.Sprint("unable to store response: ", err))
+	}
+
+	var result []map[string]interface{}
+	for _, transaction := range transactions {
+		if t, ok := transaction.(map[string]interface{}); ok {
+			result = append(result, t)
+		}
+	}
+
+	return result, nil
+}

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -11,32 +11,32 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) ([]map[string]interface{}, error) {
+func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 	session, err := h.sess.Get(ctx)
 	if err != nil {
-		return nil, errs.BadRequest(fmt.Sprint("cannot retrieve session ", err))
+		return errs.BadRequest(fmt.Sprint("cannot retrieve session ", err))
 	}
 
 	accessToken, ok := session.Get("accessToken").(string)
 	if !ok {
-		return nil, fmt.Errorf("missing required environment variables")
+		return fmt.Errorf("missing required environment variables")
 	}
 
 	tenantId, ok := session.Get("tenantID").(string)
 	if !ok {
-		return nil, fmt.Errorf("missing required environment variables")
+		return fmt.Errorf("missing required environment variables")
 	}
 
 	url := os.Getenv("TRANSACTIONS_URL")
 
 	if accessToken == "" || tenantId == "" || url == "" {
 		fmt.Printf("Examine env values: accessToken=%s, tenantId=%s, url=%s\n", accessToken, tenantId, url)
-		return nil, fmt.Errorf("missing required environment variables")
+		return fmt.Errorf("missing required environment variables")
 	}
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, errs.BadRequest(fmt.Sprint("invalid request: ", err))
+		return errs.BadRequest(fmt.Sprint("invalid request: ", err))
 	}
 
 	req.Header.Set("Authorization", "Bearer "+accessToken)
@@ -46,27 +46,27 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) ([]map[string]interface{},
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errs.BadRequest(fmt.Sprint("error handling request: ", err))
+		return errs.BadRequest(fmt.Sprint("error handling request: ", err))
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errs.BadRequest(fmt.Sprint("response status unsuccessful: ", err))
+		return errs.BadRequest(fmt.Sprint("response status unsuccessful: ", err))
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errs.BadRequest(fmt.Sprint("unable to read response body: ", err))
+		return errs.BadRequest(fmt.Sprint("unable to read response body: ", err))
 	}
 
 	var response map[string]interface{}
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, errs.BadRequest(fmt.Sprint("unable to unpack response: ", err))
+		return errs.BadRequest(fmt.Sprint("unable to unpack response: ", err))
 	}
 
 	transactions, ok := response["BankTransactions"].([]interface{})
 	if !ok {
-		return nil, errs.BadRequest(fmt.Sprint("unable to store response: ", err))
+		return errs.BadRequest(fmt.Sprint("unable to store response: ", err))
 	}
 
 	var result []map[string]interface{}
@@ -76,5 +76,5 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) ([]map[string]interface{},
 		}
 	}
 
-	return result, nil
+	return ctx.Status(fiber.StatusOK).JSON(transactions)
 }

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -69,12 +69,5 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 		return errs.BadRequest(fmt.Sprint("unable to store response: ", err))
 	}
 
-	var result []map[string]interface{}
-	for _, transaction := range transactions {
-		if t, ok := transaction.(map[string]interface{}); ok {
-			result = append(result, t)
-		}
-	}
-
 	return ctx.Status(fiber.StatusOK).JSON(transactions)
 }

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -1,0 +1,49 @@
+package xero
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/joho/godotenv"
+	"golang.org/x/oauth2"
+)
+
+type Config struct {
+	OAuth2Config *oauth2.Config
+}
+
+type Handler struct {
+	config                 *Config
+	oAuthAuthorisationCode string
+	oAuthToken             *oauth2.Token
+	oAuthHTTPClient        *http.Client
+}
+
+func NewHandler() *Handler {
+	err := godotenv.Load()
+	if err != nil {
+		fmt.Println("Error loading .env file")
+	}
+
+	oAuthScopes := []string{
+		"openid",
+		"profile",
+		"email",
+		"accounting.transactions",
+		"accounting.settings",
+		"offline_access",
+	}
+
+	oauthConfig := &oauth2.Config{
+		ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
+		ClientSecret: "wsKPVOBKg70-CHCl0ij5GDDO0JJkTOEj2qH7aFImOxvHdn0V",
+		RedirectURL:  "http://localhost:8080/callback",
+		Scopes:       oAuthScopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://login.xero.com/identity/connect/authorize",
+			TokenURL: "https://identity.xero.com/connect/token",
+		},
+	}
+
+	return &Handler{&Config{oauthConfig}, "", nil, nil}
+}

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -47,5 +47,16 @@ func NewHandler(sess *session.Store) *Handler {
 		},
 	}
 
+	// oauthConfig := &oauth2.Config{
+	// 	ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
+	// 	ClientSecret: "ILiIbOwZMKXM0jLnyF6tPCO_y9GLt-Pvf84LUEJAl-tbqz5T",
+	// 	RedirectURL:  "http://localhost:8080/callback",
+	// 	Scopes:       oAuthScopes,
+	// 	Endpoint: oauth2.Endpoint{
+	// 		AuthURL:  "https://login.xero.com/identity/connect/authorize",
+	// 		TokenURL: "https://identity.xero.com/connect/token",
+	// 	},
+	// }
+
 	return &Handler{sess, &Config{oauthConfig}, "", nil, nil}
 }

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -1,11 +1,10 @@
 package xero
 
 import (
-	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/gofiber/fiber/v2/middleware/session"
-	"github.com/joho/godotenv"
 	"golang.org/x/oauth2"
 )
 
@@ -22,10 +21,11 @@ type Handler struct {
 }
 
 func NewHandler(sess *session.Store) *Handler {
-	err := godotenv.Load()
-	if err != nil {
-		fmt.Println("Error loading .env file")
-	}
+	client_id := os.Getenv("CLIENT_ID")
+	client_secret := os.Getenv("CLIENT_SECRET")
+	redirect_url := os.Getenv("REDIRECT_URL")
+	auth_url := os.Getenv("AUTH_URL")
+	token_url := os.Getenv("TOKEN_URL")
 
 	oAuthScopes := []string{
 		"openid",
@@ -37,26 +37,15 @@ func NewHandler(sess *session.Store) *Handler {
 	}
 
 	oauthConfig := &oauth2.Config{
-		ClientID:     "ID",
-		ClientSecret: "SECRET",
-		RedirectURL:  "http://localhost:8080/callback",
+		ClientID:     client_id,
+		ClientSecret: client_secret,
+		RedirectURL:  redirect_url,
 		Scopes:       oAuthScopes,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  "https://login.xero.com/identity/connect/authorize",
-			TokenURL: "https://identity.xero.com/connect/token",
+			AuthURL:  auth_url,
+			TokenURL: token_url,
 		},
 	}
-
-	// oauthConfig := &oauth2.Config{
-	// 	ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
-	// 	ClientSecret: "ILiIbOwZMKXM0jLnyF6tPCO_y9GLt-Pvf84LUEJAl-tbqz5T",
-	// 	RedirectURL:  "http://localhost:8080/callback",
-	// 	Scopes:       oAuthScopes,
-	// 	Endpoint: oauth2.Endpoint{
-	// 		AuthURL:  "https://login.xero.com/identity/connect/authorize",
-	// 		TokenURL: "https://identity.xero.com/connect/token",
-	// 	},
-	// }
 
 	return &Handler{sess, &Config{oauthConfig}, "", nil, nil}
 }

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -35,8 +35,8 @@ func NewHandler() *Handler {
 	}
 
 	oauthConfig := &oauth2.Config{
-		ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
-		ClientSecret: "wsKPVOBKg70-CHCl0ij5GDDO0JJkTOEj2qH7aFImOxvHdn0V",
+		ClientID:     "ID",
+		ClientSecret: "SECRET",
 		RedirectURL:  "http://localhost:8080/callback",
 		Scopes:       oAuthScopes,
 		Endpoint: oauth2.Endpoint{

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gofiber/fiber/v2/middleware/session"
 	"github.com/joho/godotenv"
 	"golang.org/x/oauth2"
 )
@@ -13,13 +14,14 @@ type Config struct {
 }
 
 type Handler struct {
+	sess                   *session.Store
 	config                 *Config
 	oAuthAuthorisationCode string
 	oAuthToken             *oauth2.Token
 	oAuthHTTPClient        *http.Client
 }
 
-func NewHandler() *Handler {
+func NewHandler(sess *session.Store) *Handler {
 	err := godotenv.Load()
 	if err != nil {
 		fmt.Println("Error loading .env file")
@@ -35,8 +37,8 @@ func NewHandler() *Handler {
 	}
 
 	oauthConfig := &oauth2.Config{
-		ClientID:     "ID",
-		ClientSecret: "SECRET",
+		ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
+		ClientSecret: "wsKPVOBKg70-CHCl0ij5GDDO0JJkTOEj2qH7aFImOxvHdn0V",
 		RedirectURL:  "http://localhost:8080/callback",
 		Scopes:       oAuthScopes,
 		Endpoint: oauth2.Endpoint{
@@ -45,5 +47,5 @@ func NewHandler() *Handler {
 		},
 	}
 
-	return &Handler{&Config{oauthConfig}, "", nil, nil}
+	return &Handler{sess, &Config{oauthConfig}, "", nil, nil}
 }

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -37,8 +37,8 @@ func NewHandler(sess *session.Store) *Handler {
 	}
 
 	oauthConfig := &oauth2.Config{
-		ClientID:     "E1B6C918F29E4C48A2097A725A76C505",
-		ClientSecret: "wsKPVOBKg70-CHCl0ij5GDDO0JJkTOEj2qH7aFImOxvHdn0V",
+		ClientID:     "ID",
+		ClientSecret: "SECRET",
 		RedirectURL:  "http://localhost:8080/callback",
 		Scopes:       oAuthScopes,
 		Endpoint: oauth2.Endpoint{

--- a/backend/internal/service/handler/xero/redirect_to_xero.go
+++ b/backend/internal/service/handler/xero/redirect_to_xero.go
@@ -43,11 +43,6 @@ func (h *Handler) Callback(ctx *fiber.Ctx) error {
 	session.Set("accessToken", tok.AccessToken)
 	session.Set("refreshToken", tok.RefreshToken)
 
-	if err != nil {
-		log.Fatalf("Error updating .env file: %v", err)
-	}
-	fmt.Println(".env file updated successfully!")
-
 	url := os.Getenv("CONNECTIONS_URL")
 
 	req, err := http.NewRequest("GET", url, nil)

--- a/backend/internal/service/handler/xero/redirect_to_xero.go
+++ b/backend/internal/service/handler/xero/redirect_to_xero.go
@@ -20,18 +20,27 @@ func (h *Handler) Callback(ctx *fiber.Ctx) error {
 
 	h.oAuthAuthorisationCode = ctx.Query("code")
 
+	// Exchanges the authorization code for an access token
+	// with the Xero auth server.
 	tok, err := h.config.OAuth2Config.Exchange(
 		ctx.Context(),
 		h.oAuthAuthorisationCode,
 		oauth2.SetAuthURLParam(h.getAuthorisationHeader()),
 	)
 	if err != nil {
-		// Log and handle the error
 		return ctx.Status(fiber.StatusInternalServerError).SendString("An error occurred while trying to exchange the authorization code with the Xero API.")
 	}
 
 	// Update the server struct with the token.
 	h.oAuthToken = tok
+	session, err := h.sess.Get(ctx)
+	if err != nil {
+		return ctx.Status(fiber.StatusInternalServerError).SendString("Failed to create session")
+	}
+	session.Set("accessToken", tok.AccessToken)
+	session.Set("refreshToken", tok.RefreshToken)
+	session.Save()
+	print("ACCESS TOKEN:", tok.AccessToken)
 
 	// Set the HTTP client for subsequent requests.
 	h.oAuthHTTPClient = h.config.OAuth2Config.Client(ctx.Context(), tok)

--- a/backend/internal/service/handler/xero/redirect_to_xero.go
+++ b/backend/internal/service/handler/xero/redirect_to_xero.go
@@ -1,0 +1,47 @@
+package xero
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+	"golang.org/x/oauth2"
+)
+
+func (h *Handler) RedirectToAuthorisationEndpoint(ctx *fiber.Ctx) error {
+	// Generate the Xero authorization URL.
+	authURL := h.config.OAuth2Config.AuthCodeURL("state", oauth2.AccessTypeOffline)
+
+	// Redirect to the generated URL.
+	return ctx.Redirect(authURL, fiber.StatusTemporaryRedirect)
+}
+
+func (h *Handler) Callback(ctx *fiber.Ctx) error {
+
+	h.oAuthAuthorisationCode = ctx.Query("code")
+
+	tok, err := h.config.OAuth2Config.Exchange(
+		ctx.Context(),
+		h.oAuthAuthorisationCode,
+		oauth2.SetAuthURLParam(h.getAuthorisationHeader()),
+	)
+	if err != nil {
+		// Log and handle the error
+		return ctx.Status(fiber.StatusInternalServerError).SendString("An error occurred while trying to exchange the authorization code with the Xero API.")
+	}
+
+	// Update the server struct with the token.
+	h.oAuthToken = tok
+
+	// Set the HTTP client for subsequent requests.
+	h.oAuthHTTPClient = h.config.OAuth2Config.Client(ctx.Context(), tok)
+
+	// Redirect to the home page.
+	return ctx.Redirect("/health", fiber.StatusTemporaryRedirect)
+}
+
+func (h *Handler) getAuthorisationHeader() (string, string) {
+	return "authorization", base64.StdEncoding.EncodeToString([]byte(
+		fmt.Sprintf("Basic %s:%s", h.config.OAuth2Config.ClientID, h.config.OAuth2Config.ClientSecret),
+	))
+}

--- a/backend/internal/service/handler/xero/redirect_to_xero.go
+++ b/backend/internal/service/handler/xero/redirect_to_xero.go
@@ -2,7 +2,12 @@ package xero
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
 
 	"github.com/gofiber/fiber/v2"
 	"golang.org/x/oauth2"
@@ -17,7 +22,7 @@ func (h *Handler) RedirectToAuthorisationEndpoint(ctx *fiber.Ctx) error {
 }
 
 func (h *Handler) Callback(ctx *fiber.Ctx) error {
-
+	var tenantIDToken string
 	h.oAuthAuthorisationCode = ctx.Query("code")
 
 	// Exchanges the authorization code for an access token
@@ -39,18 +44,99 @@ func (h *Handler) Callback(ctx *fiber.Ctx) error {
 	}
 	session.Set("accessToken", tok.AccessToken)
 	session.Set("refreshToken", tok.RefreshToken)
+
+	url := "https://api.xero.com/connections"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalf("Error reading response body: %v", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("Successfully fetched connections!")
+	} else {
+		fmt.Println("Error fetching connections!")
+	}
+
+	var connections []map[string]interface{}
+	err = json.Unmarshal(body, &connections)
+	if err != nil {
+		log.Fatalf("Error parsing JSON: %v", err)
+	}
+
+	for _, connection := range connections {
+		if tenantID, ok := connection["tenantId"].(string); ok {
+			session.Set("tenantID", tenantID)
+			tenantIDToken = tenantID
+		} else {
+			fmt.Println("Tenant ID not found or is not a string")
+		}
+	}
+
 	session.Save()
-	print("ACCESS TOKEN:", tok.AccessToken)
 
 	// Set the HTTP client for subsequent requests.
 	h.oAuthHTTPClient = h.config.OAuth2Config.Client(ctx.Context(), tok)
 
+	handler := &Handler{}
+	handler.getBankTransactions(tok.AccessToken, tenantIDToken)
+
 	// Redirect to the home page.
 	return ctx.Redirect("/health", fiber.StatusTemporaryRedirect)
+
 }
 
 func (h *Handler) getAuthorisationHeader() (string, string) {
 	return "authorization", base64.StdEncoding.EncodeToString([]byte(
 		fmt.Sprintf("Basic %s:%s", h.config.OAuth2Config.ClientID, h.config.OAuth2Config.ClientSecret),
 	))
+}
+
+func (h *Handler) getBankTransactions(accessToken, tenantId string) error {
+	url := "https://api.xero.com/api.xro/2.0/BankTransactions"
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Xero-tenant-id", tenantId)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected response status: %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading response body: %w", err)
+	}
+
+	fmt.Println("Response Status:", resp.Status)
+	fmt.Println("Response Body:", string(body))
+
+	return nil
 }

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -10,7 +10,6 @@ import (
 	"arenius/internal/service/handler/xero"
 	"arenius/internal/storage"
 	"arenius/internal/storage/postgres"
-	"fmt"
 
 	"context"
 	"net/http"
@@ -96,11 +95,8 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 	app.Get("/climatiq", carbonHandler.SearchEmissionFactors)
 
 	app.Get("/bank-transactions", func(c *fiber.Ctx) error {
-		transactions, err := xeroAuthHandler.GetBankTransactions(c)
-		if err != nil {
-			return c.Status(500).SendString(fmt.Sprintf("Error fetching bank transactions: %v", err))
-		}
-		return c.JSON(transactions)
+		status := xeroAuthHandler.GetBankTransactions(c)
+		return status
 	})
 
 	return app

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -10,6 +10,7 @@ import (
 	"arenius/internal/service/handler/xero"
 	"arenius/internal/storage"
 	"arenius/internal/storage/postgres"
+	"fmt"
 
 	"context"
 	"net/http"
@@ -93,6 +94,14 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 	// Example route that uses the climatiq client
 	carbonHandler := carbon.NewHandler()
 	app.Get("/climatiq", carbonHandler.SearchEmissionFactors)
+
+	app.Get("/bank-transactions", func(c *fiber.Ctx) error {
+		transactions, err := xero.GetBankTransactions()
+		if err != nil {
+			return c.Status(500).SendString(fmt.Sprintf("Error fetching bank transactions: %v", err))
+		}
+		return c.JSON(transactions)
+	})
 
 	return app
 }

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -7,6 +7,7 @@ import (
 	"arenius/internal/service/ctxt"
 	"arenius/internal/service/handler/carbon"
 	"arenius/internal/service/handler/transaction"
+	"arenius/internal/service/handler/xero"
 	"arenius/internal/storage"
 	"arenius/internal/storage/postgres"
 
@@ -72,6 +73,13 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 	app.Get("/health", func(c *fiber.Ctx) error {
 		return c.SendStatus(http.StatusOK)
 	})
+
+	xeroAuthHandler := xero.NewHandler()
+	app.Route("/auth", func(r fiber.Router) {
+		r.Get("/xero", xeroAuthHandler.RedirectToAuthorisationEndpoint)
+	})
+
+	app.Get("/callback", xeroAuthHandler.Callback)
 
 	transactionHandler := transaction.NewHandler(repo.Transaction)
 	app.Route("/transaction", func(r fiber.Router) {

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/gofiber/fiber/v2/middleware/session"
 )
 
 type App struct {
@@ -74,10 +75,13 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 		return c.SendStatus(http.StatusOK)
 	})
 
-	xeroAuthHandler := xero.NewHandler()
+	sess := session.New()
+	xeroAuthHandler := xero.NewHandler(sess)
 	app.Route("/auth", func(r fiber.Router) {
 		r.Get("/xero", xeroAuthHandler.RedirectToAuthorisationEndpoint)
 	})
+
+	//app.Use("/xero", middleware.XeroAuth)
 
 	app.Get("/callback", xeroAuthHandler.Callback)
 

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -96,7 +96,7 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 	app.Get("/climatiq", carbonHandler.SearchEmissionFactors)
 
 	app.Get("/bank-transactions", func(c *fiber.Ctx) error {
-		transactions, err := xero.GetBankTransactions()
+		transactions, err := xeroAuthHandler.GetBankTransactions(c)
 		if err != nil {
 			return c.Status(500).SendString(fmt.Sprintf("Error fetching bank transactions: %v", err))
 		}


### PR DESCRIPTION
Finished saving tenant id for xero auth in the session and using tenant id & access token for using the xero auth APIs. 

## Description

Generate a Tenant Id using the Connections API Endpoint from Xero, store it in the session, and use that Tenant ID and Access Token for a GET Bank Transactions endpoint that lists all transactions from Generate in Xero Auth as an organization. 

## How Has This Been Tested?
Logging in terminal

#### Backend PRs

![image](https://github.com/user-attachments/assets/db3671a1-0372-4e05-aebd-464c2b199c5d)

## Checklist:
- [ X ] I have performed a self-review of my code
- [ X ] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
