### PR TITLE
Be 41 store imported transactions

### DIFF
--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -52,11 +52,12 @@ type GetLineItemsRequest struct {
 }
 
 type AddImportedLineItemRequest struct {
-	XeroLineItemID string  `json:"xero_line_item_id,omitempty"`
-	Description    string  `json:"description"`
-	Quantity       float64 `json:"quantity"`
-	UnitAmount     float64 `json:"unit_amount"`
-	CompanyID      string  `json:"company_id"`
-	ContactID      string  `json:"contact_id"`
-	CurrencyCode   string  `json:"currency_code"`
+	XeroLineItemID string    `json:"xero_line_item_id,omitempty"`
+	Description    string    `json:"description"`
+	Quantity       float64   `json:"quantity"`
+	UnitAmount     float64   `json:"unit_amount"`
+	CompanyID      string    `json:"company_id"`
+	ContactID      string    `json:"contact_id"`
+	Date           time.Time `json:"date"`
+	CurrencyCode   string    `json:"currency_code"`
 }

--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -50,3 +50,13 @@ type GetLineItemsRequest struct {
 	Date                 *time.Time `json:"date"`
 	ReconciliationStatus *bool      `json:"reconciliation_status"`
 }
+
+type AddImportedLineItemRequest struct {
+	XeroLineItemID string  `json:"xero_line_item_id,omitempty"`
+	Description    string  `json:"description"`
+	Quantity       float64 `json:"quantity"`
+	UnitAmount     float64 `json:"unit_amount"`
+	CompanyID      string  `json:"company_id"`
+	ContactID      string  `json:"contact_id"`
+	CurrencyCode   string  `json:"currency_code"`
+}

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -2,6 +2,7 @@ package xero
 
 import (
 	"arenius/internal/errs"
+	"arenius/internal/models"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,6 +44,11 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Xero-tenant-id", tenantId)
 
+	// get the current company using the Xero tenant ID
+	// TODO: how?
+
+	// req.Header.Set("If-Modified-Since", company.LastImportTime)
+
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -69,5 +75,85 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 		return errs.BadRequest(fmt.Sprint("unable to store response: ", err))
 	}
 
+	// get the current company ID using the Xero tenant ID:
+
+	// TODO send it to the repository layer (how?)
+
 	return ctx.Status(fiber.StatusOK).JSON(transactions)
+}
+
+func parseTransactions(transactions []interface{}, company models.Company) ([]models.AddImportedLineItemRequest, error) {
+	var newLineItems []models.AddImportedLineItemRequest
+	// Build an AddImportedLineItemRequest object
+	for _, transaction := range transactions {
+		txMap, ok := transaction.(map[string]interface{})
+		if !ok {
+			return nil, errs.BadRequest("Invalid Transaction format")
+		}
+
+		var contactID string
+		if txMap["Contact"] != nil {
+			contactMap, ok := txMap["Contact"].(map[string]interface{})
+			if !ok {
+				return nil, errs.BadRequest("Invalid Contact format")
+			}
+			if contactMap["ContactID"] != nil {
+				contactID = contactMap["ContactID"].(string)
+			} else {
+				return nil, errs.BadRequest("Missing ContactID")
+			}
+		}
+
+		var currencyCode string
+		if txMap["CurrencyCode"] != nil {
+			currencyCode = txMap["CurrencyCode"].(string)
+		} else {
+			currencyCode = "USD"
+		}
+
+		if txMap["LineItems"] != nil {
+			// TODO: these are currently missing from response?
+			lineItemsArray, ok := txMap["LineItems"].([]map[string]interface{})
+			if !ok {
+				return nil, errs.BadRequest("Invalid LineItems format")
+			}
+
+			for _, lineItem := range lineItemsArray {
+				var newLineItem models.AddImportedLineItemRequest
+				// newLineItem.CompanyID = company.ID TODO
+				newLineItem.CompanyID = "0a67f5d3-88b6-4e8f-aac0-5137b29917fd"
+				newLineItem.CurrencyCode = currencyCode
+				newLineItem.ContactID = contactID
+
+				if lineItem["LineItemID"] != nil {
+					newLineItem.XeroLineItemID = lineItem["LineItemID"].(string)
+				} else {
+					return nil, errs.BadRequest("Missing LineItemID")
+				}
+
+				if lineItem["Description"] != nil {
+					newLineItem.Description = lineItem["Description"].(string)
+				} else {
+					return nil, errs.BadRequest("Missing Description")
+				}
+
+				if lineItem["Quantity"] != nil {
+					newLineItem.Quantity = lineItem["Quantity"].(float64)
+				} else {
+					return nil, errs.BadRequest("Missing Quantity")
+				}
+
+				if lineItem["UnitAmount"] != nil {
+					newLineItem.UnitAmount = lineItem["UnitAmount"].(float64)
+				} else {
+					return nil, errs.BadRequest("Missing UnitAmount")
+				}
+
+				newLineItems = append(newLineItems, newLineItem)
+			}
+		}
+
+	}
+
+	return newLineItems, nil
 }

--- a/backend/internal/service/handler/xero/get_bank_transactions.go
+++ b/backend/internal/service/handler/xero/get_bank_transactions.go
@@ -110,11 +110,11 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 			return errs.BadRequest("Invalid pagination format")
 		}
 
-		itemCount, ok := pagination["itemCount"].(int)
+		itemCount, ok := pagination["itemCount"].(float64)
 		if !ok {
 			return errs.BadRequest(fmt.Sprintf("Invalid Item Count value: %s", pagination["itemCount"]))
 		}
-		remainingTransactions = itemCount == 100
+		remainingTransactions = int(itemCount) == 100
 
 		transactions = append(transactions, paginatedTransactions...)
 	}
@@ -128,7 +128,7 @@ func (h *Handler) GetBankTransactions(ctx *fiber.Ctx) error {
 	// TODO: use company PATCH endpoint instead
 	// update company.last_imported_at to now so that we don't fetch the same transactions later
 	companyLastImportTimeQuery := `
-		UPDATE company 
+		UPDATE company
 		SET last_import_time=$1
 		WHERE id=$2
 		RETURNING last_import_time;

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -1,6 +1,7 @@
 package xero
 
 import (
+	"arenius/internal/storage"
 	"net/http"
 	"os"
 
@@ -18,9 +19,10 @@ type Handler struct {
 	oAuthAuthorisationCode string
 	oAuthToken             *oauth2.Token
 	oAuthHTTPClient        *http.Client
+	repository             *storage.Repository
 }
 
-func NewHandler(sess *session.Store) *Handler {
+func NewHandler(sess *session.Store, repo *storage.Repository) *Handler {
 	client_id := os.Getenv("CLIENT_ID")
 	client_secret := os.Getenv("CLIENT_SECRET")
 	redirect_url := os.Getenv("REDIRECT_URL")
@@ -47,5 +49,5 @@ func NewHandler(sess *session.Store) *Handler {
 		},
 	}
 
-	return &Handler{sess, &Config{oauthConfig}, "", nil, nil}
+	return &Handler{sess, &Config{oauthConfig}, "", nil, nil, repo}
 }

--- a/backend/internal/service/handler/xero/handler.go
+++ b/backend/internal/service/handler/xero/handler.go
@@ -19,10 +19,11 @@ type Handler struct {
 	oAuthAuthorisationCode string
 	oAuthToken             *oauth2.Token
 	oAuthHTTPClient        *http.Client
-	repository             *storage.Repository
+	lineItemRepository     storage.LineItemRepository
+	companyRepository      storage.CompanyRepository
 }
 
-func NewHandler(sess *session.Store, repo *storage.Repository) *Handler {
+func NewHandler(sess *session.Store, lineItemRepository storage.LineItemRepository, companyRepository storage.CompanyRepository) *Handler {
 	client_id := os.Getenv("CLIENT_ID")
 	client_secret := os.Getenv("CLIENT_SECRET")
 	redirect_url := os.Getenv("REDIRECT_URL")
@@ -49,5 +50,5 @@ func NewHandler(sess *session.Store, repo *storage.Repository) *Handler {
 		},
 	}
 
-	return &Handler{sess, &Config{oauthConfig}, "", nil, nil, repo}
+	return &Handler{sess, &Config{oauthConfig}, "", nil, nil, lineItemRepository, companyRepository}
 }

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -78,10 +78,8 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 		return c.SendStatus(http.StatusOK)
 	})
 
-	xeroRepository := postgres.NewRepository(context.Background(), config.DB)
-
 	sess := session.New()
-	xeroAuthHandler := xero.NewHandler(sess, xeroRepository)
+	xeroAuthHandler := xero.NewHandler(sess, repo.LineItem, repo.Company)
 	app.Route("/auth", func(r fiber.Router) {
 		r.Get("/xero", xeroAuthHandler.RedirectToAuthorisationEndpoint)
 	})

--- a/backend/internal/service/server.go
+++ b/backend/internal/service/server.go
@@ -8,8 +8,8 @@ import (
 	"arenius/internal/service/handler/carbon"
 	"arenius/internal/service/handler/emissionsFactor"
 	"arenius/internal/service/handler/lineItem"
-	"arenius/internal/service/handler/xero"
 	"arenius/internal/service/handler/summary"
+	"arenius/internal/service/handler/xero"
 	"arenius/internal/storage"
 	"arenius/internal/storage/postgres"
 
@@ -78,8 +78,10 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 		return c.SendStatus(http.StatusOK)
 	})
 
+	xeroRepository := postgres.NewRepository(context.Background(), config.DB)
+
 	sess := session.New()
-	xeroAuthHandler := xero.NewHandler(sess)
+	xeroAuthHandler := xero.NewHandler(sess, xeroRepository)
 	app.Route("/auth", func(r fiber.Router) {
 		r.Get("/xero", xeroAuthHandler.RedirectToAuthorisationEndpoint)
 	})
@@ -110,7 +112,7 @@ func SetupApp(config config.Config, repo *storage.Repository, climatiqClient *cl
 	app.Route("/summary", func(r fiber.Router) {
 		r.Get("/gross", summaryHandler.GetGrossSummary)
 	})
-  
+
 	app.Get("/bank-transactions", xeroAuthHandler.GetBankTransactions)
 
 	return app

--- a/backend/internal/storage/postgres/schema/company.go
+++ b/backend/internal/storage/postgres/schema/company.go
@@ -1,0 +1,57 @@
+package schema
+
+import (
+	"arenius/internal/errs"
+	"arenius/internal/models"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type CompanyRepository struct {
+	db *pgxpool.Pool
+}
+
+func (r *CompanyRepository) GetCompanyByXeroTenantID(ctx context.Context, xeroTenantID string) (*models.Company, error) {
+	query := `
+		SELECT id, name, xero_tenant_id, last_import_time
+		FROM company 
+		WHERE xero_tenant_id=$1
+		LIMIT 1
+	`
+	var company models.Company
+
+	err := r.db.QueryRow(ctx, query, xeroTenantID).Scan(
+		&company.ID, &company.Name, &company.XeroTenantID, &company.LastImportTime,
+	)
+	if err != nil {
+		return nil, errs.BadRequest(fmt.Sprintf("Error finding company with Xero Tenant ID: %s, %s", xeroTenantID, err))
+	}
+	return &company, nil
+}
+
+func (r *CompanyRepository) UpdateCompanyLastImportTime(ctx context.Context, id string) (*models.Company, error) {
+	query := `
+		UPDATE company
+		SET last_import_time=$1
+		WHERE id=$2
+		RETURNING id, name, xero_tenant_id, last_import_time;
+	`
+	var company models.Company
+
+	err := r.db.QueryRow(ctx, query, time.Now().UTC(), id).Scan(
+		&company.ID, &company.Name, &company.XeroTenantID, &company.LastImportTime,
+	)
+	if err != nil {
+		return nil, errs.BadRequest(fmt.Sprintf("Unable to update company last_import_time: %s", err))
+	}
+	return &company, nil
+}
+
+func NewCompanyRepository(db *pgxpool.Pool) *CompanyRepository {
+	return &CompanyRepository{
+		db,
+	}
+}

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -187,9 +187,9 @@ func (r *LineItemRepository) AddImportedLineItems(ctx context.Context, req []mod
 			INSERT INTO line_item
 			(id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope
-			ON CONFLICT (xero_tenant_id) DO NOTHING;
+			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
 		`
+		// TODO: handle duplicate based on xero_line_item_id
 		var lineItem models.LineItem
 		err := r.db.QueryRow(ctx, query,
 			uuid.New().String(),

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -199,7 +199,7 @@ func (r *LineItemRepository) AddImportedLineItems(ctx context.Context, req []mod
 			importedLineItem.UnitAmount,
 			importedLineItem.CompanyID,
 			importedLineItem.ContactID,
-			time.Now().UTC(),
+			importedLineItem.Date.UTC(),
 			importedLineItem.CurrencyCode).
 			Scan(
 				&lineItem.ID,

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -180,6 +180,48 @@ func (r *LineItemRepository) CreateLineItem(ctx context.Context, req models.Crea
 
 }
 
+func (r *LineItemRepository) AddImportedLineItems(ctx context.Context, req []models.AddImportedLineItemRequest) ([]models.LineItem, error) {
+	var createdLineItems []models.LineItem
+	for _, importedLineItem := range req {
+		query := `
+			INSERT INTO line_item
+			(id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
+		`
+		var lineItem models.LineItem
+		err := r.db.QueryRow(ctx, query,
+			uuid.New().String(),
+			importedLineItem.XeroLineItemID,
+			importedLineItem.Description,
+			importedLineItem.Quantity,
+			importedLineItem.UnitAmount,
+			importedLineItem.CompanyID,
+			importedLineItem.ContactID,
+			time.Now().UTC(),
+			importedLineItem.CurrencyCode).
+			Scan(
+				&lineItem.ID,
+				&lineItem.XeroLineItemID,
+				&lineItem.Description,
+				&lineItem.Quantity,
+				&lineItem.UnitAmount,
+				&lineItem.CompanyID,
+				&lineItem.ContactID,
+				&lineItem.Date,
+				&lineItem.CurrencyCode,
+				&lineItem.EmissionFactorId,
+				&lineItem.CO2,
+				&lineItem.CO2Unit,
+				&lineItem.Scope)
+		if err != nil {
+			return nil, fmt.Errorf("error querying database: %w", err)
+		}
+		createdLineItems = append(createdLineItems, lineItem)
+	}
+	return createdLineItems, nil
+}
+
 func createLineItemValidations(req models.CreateLineItemRequest) ([]string, []interface{}, error) {
 	id := uuid.New().String()
 	createdAt := time.Now().UTC()

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -187,7 +187,8 @@ func (r *LineItemRepository) AddImportedLineItems(ctx context.Context, req []mod
 			INSERT INTO line_item
 			(id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
+			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope
+			ON CONFLICT (xero_tenant_id) DO NOTHING;
 		`
 		var lineItem models.LineItem
 		err := r.db.QueryRow(ctx, query,

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -15,6 +15,7 @@ type LineItemRepository interface {
 	ReconcileLineItem(ctx context.Context, lineItemId int, req models.ReconcileLineItemRequest) (*models.LineItem, error)
 	AddLineItemEmissions(ctx context.Context, req models.LineItemEmissionsRequest) (*models.LineItem, error)
 	CreateLineItem(ctx context.Context, req models.CreateLineItemRequest) (*models.LineItem, error)
+	AddImportedLineItems(ctx context.Context, req []models.AddImportedLineItemRequest) ([]models.LineItem, error)
 }
 
 type EmissionsFactorRepository interface {
@@ -36,6 +37,10 @@ type Repository struct {
 func (r *Repository) Close() error {
 	r.db.Close()
 	return nil
+}
+
+func (r *Repository) GetDB() *pgxpool.Pool {
+	return r.db
 }
 
 func NewRepository(db *pgxpool.Pool) *Repository {

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -27,11 +27,17 @@ type SummaryRepository interface {
 	GetGrossSummary(ctx context.Context, req models.GetGrossSummaryRequest) (*models.GetGrossSummaryResponse, error)
 }
 
+type CompanyRepository interface {
+	GetCompanyByXeroTenantID(ctx context.Context, xeroTenantID string) (*models.Company, error)
+	UpdateCompanyLastImportTime(ctx context.Context, id string) (*models.Company, error)
+}
+
 type Repository struct {
 	db              *pgxpool.Pool
 	LineItem        LineItemRepository
 	EmissionsFactor EmissionsFactorRepository
 	Summary         SummaryRepository
+	Company         CompanyRepository
 }
 
 func (r *Repository) Close() error {
@@ -49,5 +55,6 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 		LineItem:        schema.NewLineItemRepository(db),
 		EmissionsFactor: schema.NewEmissionsFactorRepository(db),
 		Summary:         schema.NewSummaryRepository(db),
+		Company:         schema.NewCompanyRepository(db),
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Link to Ticket](https://github.com/GenerateNU/arenius/issues/41)

<!--- Describe your changes at a high-level -->
Storing the line items pulled from Xero on the /bank-transactions endpoint. In order to actually get the line item details, the request to Xero has to be paginated. 

After pulling all the transactions that are [ModifiedAfter](https://developer.xero.com/documentation/api/accounting/banktransactions/#get-banktransactions) the company's last_import_time, the line items are parsed and sent to the repository level. Before adding the line items to the line items table, the company's last_import_time is updated.

We should think about adding a company repository to handle these internal GET and PATCH requests - using just straight SQL doesn't feel responsible/scalable. Also we need to figure out how we want to handle duplicate xero_line_item_ids (for instance, if someone updates a line item). We decided not to set xero_line_item_id as a unique column in line_items table because A) it can be null and we don't want that to be a problem and B) we should understand updating the quantity of a line item better before changing it.

One thing to note is that the date on the line items sent to the table is the date that they are created in our database. We can also change this to be the date that xero stores on the line item.

## How Has This Been Tested?

#### Backend PRs
<!--- Please include a URL for the success case. Treat this as a reference for future developers - people should be able to use this to successfully use your endpoint later on! -->
Postman URL here:

Body parameters (if required):

Postman/Supabase screenshots:

Before making the request, the company in question has a last_imported_at in 2020:
![Screenshot 2025-02-02 170732](https://github.com/user-attachments/assets/41456bfa-b829-45f5-bb38-335d897294bf)

We make the request to /bank-transactions and get these 3 transactions in return:
![Screenshot 2025-02-02 170758](https://github.com/user-attachments/assets/5e74f6be-ccce-418b-903a-383fbeeb4b40)

Here is one of the line items from the same request:
![Screenshot 2025-02-02 170805](https://github.com/user-attachments/assets/ede4b01f-0e7f-4e1e-8fc1-d53953252cc2)

After we can see the new line items in the line items table:
![Screenshot 2025-02-02 170821](https://github.com/user-attachments/assets/05fad0b4-36c3-4f5c-a865-46a505dc6b65)

And the same company got an updated last_import_time
![Screenshot 2025-02-02 170828](https://github.com/user-attachments/assets/e62f9645-9d1f-4ddb-9b3d-c55cec51bca6)

And if we make the request to /bank-transactions again, we get nothing
![Screenshot 2025-02-02 171852](https://github.com/user-attachments/assets/145a9830-a91e-49d2-b1a2-d62fe61085fc)
#### Frontend PRs
Page route (and description of to get to this flow if necessary):


Screenshots/screen recording:


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend

Closes #41 