### PR TITLE
adding new line item filter parameters

### DIFF
--- a/backend/internal/README.md
+++ b/backend/internal/README.md
@@ -32,8 +32,11 @@ GET `/line-item`
 ```go
     - Body Parameters:
         CompanyID            *string    `json:"company_id"`
-        Date                 *time.Time `json:"date"`
         ReconciliationStatus *bool      `json:"reconciliation_status"`
+        BeforeDate           *time.Time `json:"before_date"`
+        AfterDate            *time.Time `json:"after_date"`
+        Scope                *int       `json:"scope,omitempty"`
+        EmissionFactor       *string    `json:"emission_factor,omitempty"`
     - Query Parameters:
         Page  int `query:"page"`
 	    Limit int `query:"limit"`

--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -47,8 +47,11 @@ type CreateLineItemRequest struct {
 
 type GetLineItemsRequest struct {
 	CompanyID            *string    `json:"company_id"`
-	Date                 *time.Time `json:"date"`
 	ReconciliationStatus *bool      `json:"reconciliation_status"`
+	BeforeDate           *time.Time `json:"before_date"`
+	AfterDate            *time.Time `json:"after_date"`
+	Scope                *int       `json:"scope,omitempty"`
+	EmissionFactor       *string    `json:"emission_factor,omitempty"`
 }
 
 type AddImportedLineItemRequest struct {

--- a/backend/internal/service/handler/lineItem/get_line_items.go
+++ b/backend/internal/service/handler/lineItem/get_line_items.go
@@ -23,10 +23,15 @@ func (h *Handler) GetLineItems(c *fiber.Ctx) error {
 
 	if len(c.Body()) == 0 {
 		// make an empty filter params
-		filterParams = models.GetLineItemsRequest{} 
+		filterParams = models.GetLineItemsRequest{}
 	} else {
 		if err := c.BodyParser(&filterParams); err != nil {
 			return errs.BadRequest(fmt.Sprintf("error parsing request body: %v", err))
+		}
+		if filterParams.Scope != nil {
+			if *filterParams.Scope != 1 && *filterParams.Scope != 2 && *filterParams.Scope != 3 {
+				return errs.BadRequest("Scope must be 1, 2, or 3")
+			}
 		}
 	}
 

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -44,9 +44,6 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 		filterArgs = append(filterArgs, filterParams.AfterDate.UTC())
 	}
 	if filterParams.Scope != nil {
-		if *filterParams.Scope != 1 && *filterParams.Scope != 2 && *filterParams.Scope != 3 {
-			return nil, errs.BadRequest("Scope must be 1, 2, or 3")
-		}
 		filterColumns = append(filterColumns, "li.scope=")
 		filterArgs = append(filterArgs, *filterParams.Scope)
 	}

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -65,7 +65,6 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 	ORDER BY li.date DESC
 	LIMIT $1 OFFSET $2
 	`
-	fmt.Println(query)
 
 	queryArgs := append([]interface{}{pagination.Limit, pagination.GetOffset()}, filterArgs...)
 	rows, err := r.db.Query(ctx, query, queryArgs...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Link to Ticket](https://github.com/GenerateNU/arenius/issues/55)

<!--- Describe your changes at a high-level -->

Added the filter parameters BeforeDate, AfterDate, Scope, and EmissionFactor to the GET line items endpoint.

Note that currently the EmissionFactor filter parameter compares to ```emission_factor.activity_id``` - I wasn't sure if this should be ```emission_factor.name``` instead. I think either of them can make sense, so let me know your thoughts!

## How Has This Been Tested?

#### Backend PRs
<!--- Please include a URL for the success case. Treat this as a reference for future developers - people should be able to use this to successfully use your endpoint later on! -->
Postman URL here:

Body parameters (if required):

Postman/Supabase screenshots:

![Screenshot 2025-02-06 221129](https://github.com/user-attachments/assets/3dea0eed-1678-4669-8524-e8ccc0ccafa1)
![Screenshot 2025-02-06 221152](https://github.com/user-attachments/assets/b440b1b7-2a58-4110-a48d-6088e31be0b0)
![Screenshot 2025-02-06 221258](https://github.com/user-attachments/assets/ee861aea-b0cb-4f0e-9da3-848edc89811a)
![Screenshot 2025-02-06 221651](https://github.com/user-attachments/assets/dd79f788-6bd0-4000-827c-892cfdac2163)
![Screenshot 2025-02-06 221911](https://github.com/user-attachments/assets/6eb0d9ca-5214-4241-8c9a-ddf7e99b9153)


#### Frontend PRs
Page route (and description of to get to this flow if necessary):

Screenshots/screen recording:


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend


Closes #55 
