### PR TITLE
Update get line items endpoint to take query params instead of body params

### DIFF
--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -46,12 +46,12 @@ type CreateLineItemRequest struct {
 }
 
 type GetLineItemsRequest struct {
-	CompanyID            *string    `json:"company_id"`
-	ReconciliationStatus *bool      `json:"reconciliation_status"`
-	BeforeDate           *time.Time `json:"before_date"`
-	AfterDate            *time.Time `json:"after_date"`
-	Scope                *int       `json:"scope,omitempty"`
-	EmissionFactor       *string    `json:"emission_factor,omitempty"`
+	CompanyID            *string    `query:"company_id"`
+	ReconciliationStatus *bool      `query:"reconciliation_status"`
+	BeforeDate           *time.Time `query:"before_date"`
+	AfterDate            *time.Time `query:"after_date"`
+	Scope                *int       `query:"scope"`
+	EmissionFactor       *string    `query:"emission_factor"`
 }
 
 type AddImportedLineItemRequest struct {

--- a/backend/internal/service/handler/lineItem/get_line_items.go
+++ b/backend/internal/service/handler/lineItem/get_line_items.go
@@ -21,17 +21,13 @@ func (h *Handler) GetLineItems(c *fiber.Ctx) error {
 
 	var filterParams models.GetLineItemsRequest
 
-	if len(c.Body()) == 0 {
-		// make an empty filter params
-		filterParams = models.GetLineItemsRequest{}
-	} else {
-		if err := c.BodyParser(&filterParams); err != nil {
-			return errs.BadRequest(fmt.Sprintf("error parsing request body: %v", err))
-		}
-		if filterParams.Scope != nil {
-			if *filterParams.Scope != 1 && *filterParams.Scope != 2 && *filterParams.Scope != 3 {
-				return errs.BadRequest("Scope must be 1, 2, or 3")
-			}
+	if err := c.QueryParser(&filterParams); err != nil {
+		fmt.Println(filterParams)
+		return errs.BadRequest(fmt.Sprintf("error parsing request body: %v", err))
+	}
+	if filterParams.Scope != nil {
+		if *filterParams.Scope != 1 && *filterParams.Scope != 2 && *filterParams.Scope != 3 {
+			return errs.BadRequest("Scope must be 1, 2, or 3")
 		}
 	}
 


### PR DESCRIPTION
I forgot that [GET endpoints aren't supposed to take body parameters!](https://masteringjs.io/tutorials/axios/get-with-data) I only discovered this while trying to make an axios call from the FE, where sending a request body is not allowed. so, this PR updates the GET line items endpoint to take query parameters instead. 

[followed the fiber docs](https://docs.gofiber.io/api/ctx/#queryparser) to change the tags to "query" instead of "json"

@jacktoncelli since your ticket involves this endpoint

works with new query param:
<img width="1002" alt="image" src="https://github.com/user-attachments/assets/c6b9a1f9-96e0-428f-ae8e-5c0952b1531d" />


also works fine with empty params:
<img width="999" alt="image" src="https://github.com/user-attachments/assets/dd898e64-9ff7-48c4-a55f-3971695e48ed" />
