### PR TITLE
LineItemWithDetails model and CollectRows cleanup

### DIFF
--- a/backend/internal/models/line_item.go
+++ b/backend/internal/models/line_item.go
@@ -18,6 +18,11 @@ type LineItem struct {
 	CO2Unit          *string   `json:"co2_unit,omitempty"`
 }
 
+type LineItemWithDetails struct {
+	LineItem
+	EmissionFactorName *string `json:"emission_factor_name,omitempty"`
+}
+
 type ReconcileLineItemRequest struct {
 	ID              string  `json:"id"`
 	EmissionsFactor string  `json:"emission_factor,omitempty"`

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -19,7 +19,7 @@ type LineItemRepository struct {
 	db *pgxpool.Pool
 }
 
-func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItem, error) {
+func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItemWithDetails, error) {
 	filterQuery := "WHERE 1=1"
 
 	if filterParams.ReconciliationStatus != nil {
@@ -62,7 +62,7 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 	}
 
 	query := `
-	SELECT li.id, li.xero_line_item_id, li.description, li.quantity, li.unit_amount, li.company_id, li.contact_id, li.date, li.currency_code, li.emission_factor_id, ef.name, li.co2, li.co2_unit, li.scope
+	SELECT li.id, li.xero_line_item_id, li.description, li.quantity, li.unit_amount, li.company_id, li.contact_id, li.date, li.currency_code, li.emission_factor_id, ef.name as emission_factor_name, li.co2, li.co2_unit, li.scope
 	FROM line_item li LEFT JOIN emission_factor ef ON li.emission_factor_id = ef.activity_id ` + filterQuery + `
 	ORDER BY li.date DESC
 	LIMIT $1 OFFSET $2
@@ -75,27 +75,9 @@ func (r *LineItemRepository) GetLineItems(ctx context.Context, pagination utils.
 	}
 	defer rows.Close()
 
-	var lineItems []models.LineItem
-	for rows.Next() {
-		var lineItem models.LineItem
-		if err := rows.Scan(
-			&lineItem.ID,
-			&lineItem.XeroLineItemID,
-			&lineItem.Description,
-			&lineItem.Quantity,
-			&lineItem.UnitAmount,
-			&lineItem.CompanyID,
-			&lineItem.ContactID,
-			&lineItem.Date,
-			&lineItem.CurrencyCode,
-			&lineItem.EmissionFactorId,
-			&lineItem.CO2,
-			&lineItem.CO2Unit,
-			&lineItem.Scope,
-		); err != nil {
-			return nil, err
-		}
-		lineItems = append(lineItems, lineItem)
+	lineItems, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.LineItemWithDetails])
+	if err != nil {
+		return nil, err
 	}
 
 	return lineItems, nil
@@ -159,21 +141,8 @@ func (r *LineItemRepository) AddLineItemEmissions(ctx context.Context, req model
 		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope
 	`
 
-	var lineItem models.LineItem
-	err := r.db.QueryRow(ctx, query, req.CO2, req.CO2Unit, req.LineItemId).Scan(
-		&lineItem.ID,
-		&lineItem.XeroLineItemID,
-		&lineItem.Description,
-		&lineItem.Quantity,
-		&lineItem.UnitAmount,
-		&lineItem.CompanyID,
-		&lineItem.ContactID,
-		&lineItem.Date,
-		&lineItem.CurrencyCode,
-		&lineItem.EmissionFactorId,
-		&lineItem.CO2,
-		&lineItem.CO2Unit,
-		&lineItem.Scope)
+	rows, err := r.db.Query(ctx, query, req.CO2, req.CO2Unit, req.LineItemId)
+	lineItem, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.LineItem])
 
 	if err != nil {
 		return nil, fmt.Errorf("error querying database: %w", err)
@@ -200,21 +169,9 @@ func (r *LineItemRepository) CreateLineItem(ctx context.Context, req models.Crea
 		VALUES (` + strings.Join(numInputs, ", ") + `)
 		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
 	`
-	var lineItem models.LineItem
-	err := r.db.QueryRow(ctx, query, queryArgs...).Scan(
-		&lineItem.ID,
-		&lineItem.XeroLineItemID,
-		&lineItem.Description,
-		&lineItem.Quantity,
-		&lineItem.UnitAmount,
-		&lineItem.CompanyID,
-		&lineItem.ContactID,
-		&lineItem.Date,
-		&lineItem.CurrencyCode,
-		&lineItem.EmissionFactorId,
-		&lineItem.CO2,
-		&lineItem.CO2Unit,
-		&lineItem.Scope)
+
+	rows, err := r.db.Query(ctx, query, queryArgs...)
+	lineItem, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.LineItem])
 
 	if err != nil {
 		return nil, fmt.Errorf("error querying database: %w", err)
@@ -269,7 +226,7 @@ func (r *LineItemRepository) AddImportedLineItems(ctx context.Context, req []mod
 				unit_amount=EXCLUDED.unit_amount, company_id=EXCLUDED.company_id,
 				contact_id=EXCLUDED.contact_id, date=EXCLUDED.date, currency_code=EXCLUDED.currency_code,
 				emission_factor_id=NULL, co2=NULL, co2_unit=NULL, scope=NULL
-			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, NULL as emission_factor_name, co2, co2_unit, scope;
+			RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
 		`
 		rows, err := r.db.Query(ctx, query, queryArgs...)
 		if err != nil {

--- a/backend/internal/storage/postgres/schema/line_item.go
+++ b/backend/internal/storage/postgres/schema/line_item.go
@@ -141,7 +141,7 @@ func (r *LineItemRepository) AddLineItemEmissions(ctx context.Context, req model
 		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope
 	`
 
-	rows, err := r.db.Query(ctx, query, req.CO2, req.CO2Unit, req.LineItemId)
+	rows, _ := r.db.Query(ctx, query, req.CO2, req.CO2Unit, req.LineItemId)
 	lineItem, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.LineItem])
 
 	if err != nil {
@@ -170,7 +170,7 @@ func (r *LineItemRepository) CreateLineItem(ctx context.Context, req models.Crea
 		RETURNING id, xero_line_item_id, description, quantity, unit_amount, company_id, contact_id, date, currency_code, emission_factor_id, co2, co2_unit, scope;
 	`
 
-	rows, err := r.db.Query(ctx, query, queryArgs...)
+	rows, _ := r.db.Query(ctx, query, queryArgs...)
 	lineItem, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.LineItem])
 
 	if err != nil {

--- a/backend/internal/storage/storage.go
+++ b/backend/internal/storage/storage.go
@@ -12,7 +12,7 @@ import (
 
 // Interfaces for repository layer.
 type LineItemRepository interface {
-	GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItem, error)
+	GetLineItems(ctx context.Context, pagination utils.Pagination, filterParams models.GetLineItemsRequest) ([]models.LineItemWithDetails, error)
 	ReconcileLineItem(ctx context.Context, lineItemId string, req models.ReconcileLineItemRequest) (*models.LineItem, error)
 	AddLineItemEmissions(ctx context.Context, req models.LineItemEmissionsRequest) (*models.LineItem, error)
 	CreateLineItem(ctx context.Context, req models.CreateLineItemRequest) (*models.LineItem, error)


### PR DESCRIPTION
this creates a new type, LineItemWithDetails, to include the extra "emissions_factor_name" value that the frontend needs. I decided to make it its own model since only one endpoint needs it (our GET endpoint), and it was causing slight issues for the other endpoints (like needing to SELECT an extra row in each of our SQL queries). We also might need other fields in the future (other "details") that may not be necessary every time we're dealing with a line item struct but are necessary for the frontend

i also cleaned up the line item queries so they don't manually scan and instead use the CollectRows method