### PR TITLE
Use context for line items

### DIFF
--- a/frontend/src/app/transactions/page.tsx
+++ b/frontend/src/app/transactions/page.tsx
@@ -1,38 +1,25 @@
-"use client";
-
 import ItemForm from "@/components/transactions/ItemForm";
-import { useEffect, useState } from "react";
-import { fetchLineItems } from "@/services/lineItems";
-import { LineItem } from "@/types";
-import { LineItemTable } from "../../components/transactions/LineItemTable";
-import { columns } from "../../components/transactions/columns";
+import LineItemTable from "@/components/transactions/LineItemTable";
+import { LineItemsProvider } from "@/context/LineItemsContext";
 
 export default function Transactions() {
-  const [data, setData] = useState<LineItem[]>([]);
-
-  const getItems = async () => {
-    const items = await fetchLineItems();
-    setData(items);
-  };
-
-  useEffect(() => {
-    getItems();
-  }, []);
-
   return (
-    <div className="p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)] flex-1">
-      <div>
-        <p className="font-bold text-xl">Add a new line item</p>
-        <ItemForm handleSubmit={getItems} />
+    <LineItemsProvider>
+      <div className={styles.container}>
+        <div>
+          <p className={styles.formTitle}>Add a new line item</p>
+          <ItemForm />
+        </div>
+        <hr className={styles.spacer} />
+        <LineItemTable />
       </div>
-      <hr className="mb-4 border border-black-100" />
-
-      <LineItemTable
-        columns={columns}
-        data={data}
-        getRowId={(row) => row.id}
-        onReconcile={getItems}
-      />
-    </div>
+    </LineItemsProvider>
   );
 }
+
+const styles = {
+  container:
+    "p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)] flex-1",
+  formTitle: "font-bold text-xl",
+  spacer: "mb-4 border border-black-100",
+};

--- a/frontend/src/components/transactions/ItemForm.tsx
+++ b/frontend/src/components/transactions/ItemForm.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React from "react";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,10 +22,7 @@ import {
 } from "../ui/select";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-
-type FormProps = {
-  handleSubmit: () => void;
-};
+import { useLineItems } from "@/context/LineItemsContext";
 
 const CURRENCIES = ["USD", "EUR", "GBP", "JPY", "AUD"];
 
@@ -33,7 +32,9 @@ const formSchema = z.object({
   currency_code: z.enum([...CURRENCIES] as [string, ...string[]]),
 });
 
-export default function ItemForm({ handleSubmit }: FormProps) {
+export default function ItemForm() {
+  const { fetchData } = useLineItems();
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -49,9 +50,10 @@ export default function ItemForm({ handleSubmit }: FormProps) {
       unit_amount: values.price,
       currency_code: values.currency_code,
     });
-    handleSubmit();
+    fetchData();
     form.reset();
   }
+
   return (
     <Form {...form}>
       <form

--- a/frontend/src/components/transactions/LineItemTable.tsx
+++ b/frontend/src/components/transactions/LineItemTable.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import { useState } from "react";
-
 import {
-  ColumnDef,
   flexRender,
   getCoreRowModel,
   SortingState,
   useReactTable,
   getSortedRowModel,
 } from "@tanstack/react-table";
-
 import {
   Table,
   TableBody,
@@ -21,7 +18,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "../ui/button";
 import { reconcileBatch } from "@/services/lineItems";
-import { EmissionsFactor, ReconcileBatchRequest } from "@/types";
+import { EmissionsFactor, LineItem, ReconcileBatchRequest } from "@/types";
 import {
   Select,
   SelectContent,
@@ -30,31 +27,22 @@ import {
   SelectValue,
 } from "../ui/select";
 import CategorySelector from "./CategorySelector";
+import { useLineItems } from "@/context/LineItemsContext";
+import { columns } from "./columns";
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
-  data: TData[];
-  getRowId: (row: TData) => string;
-  onReconcile: () => void;
-}
-
-export function LineItemTable<TData, TValue>({
-  columns,
-  data,
-  getRowId,
-  onReconcile,
-}: DataTableProps<TData, TValue>) {
+export default function LineItemTable<TValue>() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [scope, setScope] = useState("");
   const [emissionsFactor, setEmissionsFactor] = useState<EmissionsFactor>();
+  const { items, fetchData } = useLineItems();
 
   const table = useReactTable({
-    data,
+    data: items,
     columns,
     getCoreRowModel: getCoreRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
-    getRowId,
+    getRowId: (row: LineItem) => row.id,
     state: {
       sorting,
     },
@@ -74,7 +62,7 @@ export function LineItemTable<TData, TValue>({
     table.resetRowSelection();
     setScope("");
     setEmissionsFactor(undefined);
-    onReconcile();
+    fetchData();
   }
 
   return (

--- a/frontend/src/components/transactions/LineItemTable.tsx
+++ b/frontend/src/components/transactions/LineItemTable.tsx
@@ -30,7 +30,7 @@ import CategorySelector from "./CategorySelector";
 import { useLineItems } from "@/context/LineItemsContext";
 import { columns } from "./columns";
 
-export default function LineItemTable<TValue>() {
+export default function LineItemTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [scope, setScope] = useState("");
   const [emissionsFactor, setEmissionsFactor] = useState<EmissionsFactor>();

--- a/frontend/src/context/LineItemsContext.tsx
+++ b/frontend/src/context/LineItemsContext.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+import { fetchLineItems } from "@/services/lineItems";
+import { LineItem } from "@/types";
+
+interface LineItemsContextValue {
+  items: LineItem[];
+  fetchData: () => void;
+}
+
+const LineItemsContext = createContext<LineItemsContextValue | undefined>(
+  undefined
+);
+
+export const LineItemsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [items, setItems] = useState<LineItem[]>([]);
+
+  const fetchData = async () => {
+    const items = await fetchLineItems();
+    setItems(items);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    <LineItemsContext.Provider value={{ items, fetchData }}>
+      {children}
+    </LineItemsContext.Provider>
+  );
+};
+
+export const useLineItems = () => {
+  const context = useContext(LineItemsContext);
+  if (!context) {
+    throw new Error("useLineItems must be used within a DataProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR creates a context provider for the line items table state. This is because the table functionality spreads into a bunch of components, so rather than prop drilling, [context](https://react.dev/reference/react/useContext) is a better approach. Form and reconciliation functionality still works the same, and this should make search/filter easier to implement

## How Has This Been Tested?

#### Frontend PRs
Page route (and description of to get to this flow if necessary):

http://localhost:3000/transactions

Screen recording

https://github.com/user-attachments/assets/5c3cb299-ac76-4b9f-9ff0-893c03fcee1a



## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
