### PR TITLE
reconciled toggle (cool stuff)

### DIFF
--- a/frontend/src/app/(main)/transactions/page.tsx
+++ b/frontend/src/app/(main)/transactions/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import { useState } from "react";
+import { LineItemsProvider, useLineItems } from "@/context/LineItemsContext";
+
 import LineItemTable from "@/components/transactions/LineItemTable";
 import LineItemTableFilters from "@/components/transactions/LineItemTableFilters";
-import { LineItemsProvider, useLineItems } from "@/context/LineItemsContext";
-import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import ManualEntryModal from "@/components/transactions/ManualEntryModal";
+import {
+  reconciledColumns,
+  unreconciledColumns,
+} from "@/components/transactions/columns";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { fetchLineItems } from "@/services/lineItems";
+import { Search } from "lucide-react";
 
 export default function Transactions() {
   return (
@@ -16,8 +23,8 @@ export default function Transactions() {
   );
 }
 
-
 function TransactionsContent() {
+  const [reconciled, setReconciled] = useState(false);
   const { filters, setFilters } = useLineItems();
   const searchTerm = filters.searchTerm || "";
 
@@ -25,11 +32,13 @@ function TransactionsContent() {
     setFilters({ ...filters, searchTerm: e.target.value });
   };
 
+  const updateReconciled = (update: boolean) => {
+    setReconciled(update);
+    setFilters({ ...filters, reconciled: update });
+  };
+
   return (
     <div className={styles.container}>
-      {/* <hr className={styles.spacer} /> */}
-
-      {/* Title and Search Bar in One Line */}
       <div className="flex items-center justify-between mb-4">
         <p className={styles.formTitle}>Transactions</p>
         <div className="flex space-x-8">
@@ -46,8 +55,25 @@ function TransactionsContent() {
         </div>
       </div>
 
+      <div className={styles.reconciliationToggle}>
+        <Button
+          variant={reconciled ? "default" : "ghost"}
+          onClick={() => updateReconciled(true)}
+        >
+          Reconciled
+        </Button>
+        <Button
+          variant={reconciled ? "ghost" : "default"}
+          onClick={() => updateReconciled(false)}
+        >
+          Unreconciled
+        </Button>
+      </div>
+
       <LineItemTableFilters />
-      <LineItemTable />
+      <LineItemTable
+        columns={reconciled ? reconciledColumns : unreconciledColumns}
+      />
     </div>
   );
 }
@@ -61,4 +87,5 @@ const styles = {
     "absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500",
   input:
     "pl-10 py-2 rounded-full bg-gray-100 border-none focus:ring-0 w-full shadow-sm",
+  reconciliationToggle: "flex space-x-4",
 };

--- a/frontend/src/components/transactions/LineItemTable.tsx
+++ b/frontend/src/components/transactions/LineItemTable.tsx
@@ -8,6 +8,7 @@ import {
   useReactTable,
   getSortedRowModel,
   Row,
+  ColumnDef,
 } from "@tanstack/react-table";
 import {
   Table,
@@ -19,22 +20,28 @@ import {
 } from "@/components/ui/table";
 import { LineItem } from "@/types";
 import { useLineItems } from "@/context/LineItemsContext";
-import { columns } from "./columns";
 import LineItemTableActions from "./LineItemTableActions";
-import  { ModalDialog } from "./ModalDialog";
-import Image from "next/image"
+import { ModalDialog } from "./ModalDialog";
+import Image from "next/image";
+import { LoadingSpinner } from "../ui/loading";
 
-export default function LineItemTable() {
+export type LineItemTableProps = {
+  columns: ColumnDef<LineItem>[];
+};
+
+export default function LineItemTable({ columns }: LineItemTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
-  const { data: items } = useLineItems();
+  const { data, loading } = useLineItems();
 
-  const [selectedRowData, setSelectedRowData] = useState<Row<LineItem> | null>(null);
+  const [selectedRowData, setSelectedRowData] = useState<Row<LineItem> | null>(
+    null
+  );
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const { fetchData } = useLineItems();
 
   const table = useReactTable({
-    data: items,
+    data,
     columns,
     getCoreRowModel: getCoreRowModel(),
     onSortingChange: setSorting,
@@ -51,9 +58,17 @@ export default function LineItemTable() {
   };
 
   const handleReconcileSuccess = () => {
-    fetchData(); 
-    setIsDialogOpen(false); 
+    fetchData();
+    setIsDialogOpen(false);
   };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
 
   return (
     <>
@@ -81,28 +96,28 @@ export default function LineItemTable() {
             {table.getRowModel().rows?.length ? (
               table.getRowModel().rows.map((row) => (
                 <TableRow
-                key={row.id}
-                data-state={row.getIsSelected() && "selected"}
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
                 >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext()
                       )}
+                    </TableCell>
+                  ))}
+                  <TableCell>
+                    <Image
+                      src="/arrow.svg"
+                      alt="Reconcile"
+                      width={24}
+                      height={24}
+                      onClick={() => openReconcileDialog(row)}
+                      style={{ cursor: "pointer" }}
+                    />
                   </TableCell>
-                ))}
-                <TableCell>
-                  <Image
-                    src="/arrow.svg" 
-                    alt="Reconcile"
-                    width={24}  
-                    height={24}
-                    onClick={() => openReconcileDialog(row)}
-                    style={{ cursor: "pointer" }}  
-                  />
-                </TableCell>
-              </TableRow>
+                </TableRow>
               ))
             ) : (
               <TableRow>
@@ -132,4 +147,3 @@ export default function LineItemTable() {
     </>
   );
 }
-

--- a/frontend/src/components/transactions/columns.tsx
+++ b/frontend/src/components/transactions/columns.tsx
@@ -5,90 +5,100 @@ import { ColumnHeader } from "@/components/ui/columnHeader";
 import { LineItem } from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
 
-export const columns: ColumnDef<LineItem>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        className="ml-2"
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
+const selectColumn: ColumnDef<LineItem> = {
+  id: "select",
+  header: ({ table }) => (
+    <Checkbox
+      className="ml-2"
+      checked={
+        table.getIsAllPageRowsSelected() ||
+        (table.getIsSomePageRowsSelected() && "indeterminate")
+      }
+      onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+      aria-label="Select all"
+    />
+  ),
+  cell: ({ row }) => (
+    <Checkbox
+      checked={row.getIsSelected()}
+      onCheckedChange={(value) => row.toggleSelected(!!value)}
+      aria-label="Select row"
+    />
+  ),
+};
+const dateColumn: ColumnDef<LineItem> = {
+  accessorKey: "date",
+  header: ({ column }) => {
+    return <ColumnHeader name="Date" column={column} />;
   },
-  {
-    accessorKey: "date",
-    header: ({ column }) => {
-      return <ColumnHeader name="Date" column={column} />;
-    },
-    cell: ({ row }) => {
-      const date = new Date(row.getValue("date"));
-      const formattedDate = date.getMonth() + 1 + "/" + date.getDate();
-      return <div className="font-medium">{formattedDate}</div>;
-    },
+  cell: ({ row }) => {
+    const date = new Date(row.getValue("date"));
+    const formattedDate = date.getMonth() + 1 + "/" + date.getDate();
+    return <div className="font-medium">{formattedDate}</div>;
   },
-  {
-    accessorKey: "description",
-    header: ({ column }) => {
-      return <ColumnHeader name="Name" column={column} />;
-    },
-  },
+};
 
-  {
-    accessorKey: "emission_factor_name",
-    header: ({ column }) => {
-      return <ColumnHeader name="Emissions Factor" column={column} />;
-    },
+const descriptionColumn: ColumnDef<LineItem> = {
+  accessorKey: "description",
+  header: ({ column }) => {
+    return <ColumnHeader name="Name" column={column} />;
   },
+};
 
-  {
-    accessorKey: "contact_name",
-    header: ({ column }) => {
-      return <ColumnHeader name="Contact" column={column} />;
-    },
+const emissionFactorColumn: ColumnDef<LineItem> = {
+  accessorKey: "emission_factor_name",
+  header: ({ column }) => {
+    return <ColumnHeader name="Emissions Factor" column={column} />;
   },
-
-  {
-    accessorKey: "co2",
-    header: ({ column }) => {
-      return (
-        <ColumnHeader name="CO2" column={column} />
-      );
-    },
-    cell: ({ row }) => {
-      const co2 = parseFloat(row.getValue("co2"));
-      const formatted = !Number.isNaN(co2) ? `${co2} kg` : "";
-
-      return <div className="font-medium">{formatted}</div>;
-    },
+};
+const contactColumn: ColumnDef<LineItem> = {
+  accessorKey: "contact_name",
+  header: ({ column }) => {
+    return <ColumnHeader name="Contact" column={column} />;
   },
-
-  {
-    accessorKey: "total_amount",
-    header: ({ column }) => {
-      return (
-        <ColumnHeader name="Amount" column={column} className="text-right" />
-      );
-    },
-    cell: ({ row }) => {
-      const amount = parseFloat(row.getValue("total_amount"));
-      const formatted = new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(amount);
-
-      return <div className="text-right font-medium pr-4">{formatted}</div>;
-    },
+};
+const co2Column: ColumnDef<LineItem> = {
+  accessorKey: "co2",
+  header: ({ column }) => {
+    return <ColumnHeader name="CO2" column={column} />;
   },
+  cell: ({ row }) => {
+    const co2 = parseFloat(row.getValue("co2"));
+    const formatted = !Number.isNaN(co2) ? `${co2} kg` : "";
+
+    return <div className="font-medium">{formatted}</div>;
+  },
+};
+const amountColumn: ColumnDef<LineItem> = {
+  accessorKey: "total_amount",
+  header: ({ column }) => {
+    return (
+      <ColumnHeader name="Amount" column={column} className="text-right" />
+    );
+  },
+  cell: ({ row }) => {
+    const amount = parseFloat(row.getValue("total_amount"));
+    const formatted = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(amount);
+
+    return <div className="text-right font-medium pr-4">{formatted}</div>;
+  },
+};
+
+export const unreconciledColumns: ColumnDef<LineItem>[] = [
+  selectColumn,
+  dateColumn,
+  descriptionColumn,
+  contactColumn,
+  amountColumn,
+];
+export const reconciledColumns: ColumnDef<LineItem>[] = [
+  dateColumn,
+  descriptionColumn,
+  emissionFactorColumn,
+  co2Column,
+  contactColumn,
+  amountColumn,
 ];

--- a/frontend/src/components/ui/loading.tsx
+++ b/frontend/src/components/ui/loading.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+export type LoadingSpinnerProps = {
+  className?: string;
+};
+
+export const LoadingSpinner = ({ className }: LoadingSpinnerProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn("animate-spin", className)}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+};

--- a/frontend/src/services/lineItems.ts
+++ b/frontend/src/services/lineItems.ts
@@ -7,40 +7,35 @@ import {
 } from "../types";
 import apiClient from "./apiClient";
 
-function buildQueryParams(filters: LineItemFilters) {
-  const params: Record<string, string | Date | undefined> = {};
+function buildQueryParams(filters: LineItemFilters): URLSearchParams {
+  const params = new URLSearchParams();
 
   if (filters?.dates) {
-    params.after_date = filters.dates.from;
-    params.before_date = filters.dates.to;
+    if (filters.dates.from)
+      params.append("after_date", filters.dates.from.toISOString());
+    if (filters.dates.to)
+      params.append("before_date", filters.dates.to.toISOString());
   }
 
-  if (filters?.emissionFactor) {
-    params.emission_factor = filters.emissionFactor;
-  }
-  if (filters?.minPrice) {
-    params.min_price = filters.minPrice?.toString();
-  }
-  if (filters?.maxPrice) {
-    params.max_price = filters.maxPrice?.toString();
-  }
-  if (filters?.searchTerm) {
-    params.search_term = filters.searchTerm;
-  }
-  if (filters?.company_id) {
-    params.company_id = filters.company_id;
-  }
-  if (filters?.contact_id) {
-    params.contact_id = filters.contact_id;
-  }
+  if (filters?.emissionFactor)
+    params.append("emission_factor", filters.emissionFactor);
+  if (filters?.minPrice)
+    params.append("min_price", filters.minPrice.toString());
+  if (filters?.maxPrice)
+    params.append("max_price", filters.maxPrice.toString());
+  if (filters?.reconciled != null)
+    params.append("reconciliation_status", filters.reconciled.toString());
+
+  if (filters?.searchTerm) params.append("search_term", filters.searchTerm);
+  if (filters?.company_id) params.append("company_id", filters.company_id);
+  if (filters?.contact_id) params.append("contact_id", filters.contact_id);
 
   return params;
 }
 
 export async function fetchLineItems(
-  filters: LineItemFilters,
+  filters: LineItemFilters
 ): Promise<LineItem[]> {
-
   try {
     const response = await apiClient.get("/line-item", {
       params: buildQueryParams(filters),
@@ -56,7 +51,6 @@ export async function createLineItem(
   item: CreateLineItemRequest,
   companyId: string
 ): Promise<void> {
-  
   const new_item = {
     description: item.description,
     total_amount: item.total_amount,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -19,6 +19,7 @@ export interface LineItemFilters {
   searchTerm?: string;
   company_id?: string;
   contact_id?: string;
+  reconciled?: boolean;
 }
 
 export type CreateLineItemRequest = {
@@ -50,7 +51,7 @@ export type ReconcileRequest = {
   scope?: number;
   emissionsFactorId?: string;
   contactId?: string;
-}
+};
 
 export type EmissionsFactor = {
   name: string;
@@ -60,7 +61,7 @@ export type EmissionsFactor = {
 export type Price = {
   minPrice: number;
   maxPrice: number;
-}
+};
 
 export type EmissionsFactorCategory = {
   name: string;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

this updates the transactions page so that we can toggle between reconciled and unreconciled transactions.

to-do:
- make it so that transactions are in different sections by scope
- make loading smoother?

<!--- Describe your changes at a high-level -->

## How Has This Been Tested?

#### Frontend PRs
Page route (and description of to get to this flow if necessary):
http://localhost:3000/transactions

Screenshots/screen recording:
https://github.com/user-attachments/assets/0f3d6ccf-a0a8-4940-ac99-cadc1ea05ffc


## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
