### PR TITLE
Toggle line items by reconcilation and scope (naive version)

### DIFF
--- a/frontend/src/app/(main)/transactions/page.tsx
+++ b/frontend/src/app/(main)/transactions/page.tsx
@@ -1,17 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import LineItemTable from "@/components/transactions/LineItemTable";
-import LineItemTableFilters from "@/components/transactions/LineItemTableFilters";
-import { LineItemsProvider, useLineItems } from "@/context/LineItemsContext";
 import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import ManualEntryModal from "@/components/transactions/ManualEntryModal";
-import { fetchLineItems } from "@/services/lineItems";
+import { LineItemsProvider, useLineItems } from "@/context/LineItemsContext";
 import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
-import { Button } from "@/components/ui/button";
+import { fetchLineItems } from "@/services/lineItems";
+import ManualEntryModal from "@/components/transactions/ManualEntryModal";
 import ReconciledView from "@/components/transactions/ReconciledView";
 import UnreconciledView from "@/components/transactions/UnreconciledView";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 export default function Transactions() {
   return (

--- a/frontend/src/app/(main)/transactions/page.tsx
+++ b/frontend/src/app/(main)/transactions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import LineItemTable from "@/components/transactions/LineItemTable";
 import LineItemTableFilters from "@/components/transactions/LineItemTableFilters";
 import { LineItemsProvider, useLineItems } from "@/context/LineItemsContext";
@@ -9,6 +9,9 @@ import { Input } from "@/components/ui/input";
 import ManualEntryModal from "@/components/transactions/ManualEntryModal";
 import { fetchLineItems } from "@/services/lineItems";
 import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
+import { Button } from "@/components/ui/button";
+import ReconciledView from "@/components/transactions/ReconciledView";
+import UnreconciledView from "@/components/transactions/UnreconciledView";
 
 export default function Transactions() {
   return (
@@ -19,19 +22,27 @@ export default function Transactions() {
 }
 
 function TransactionsContent() {
+  const [reconciled, setReconciled] = useState(false);
   const { filters, setFilters } = useLineItems();
-  const { searchTerm, setSearchTerm, debouncedTerm } = useDebouncedSearch(filters.searchTerm);
+  const { searchTerm, setSearchTerm, debouncedTerm } = useDebouncedSearch(
+    filters.searchTerm
+  );
 
   useEffect(() => {
     setFilters({ ...filters, searchTerm: debouncedTerm });
   }, [debouncedTerm]);
 
+  const updateReconciled = (update: boolean) => {
+    setReconciled(update);
+    setFilters({ ...filters, reconciled: update });
+  };
+
   return (
     <div className={styles.container}>
-      <div className="flex items-center justify-between mb-4">
+      <div className={styles.header}>
         <p className={styles.formTitle}>Transactions</p>
-        <div className="flex space-x-8">
-          <div className="relative w-80">
+        <div className={styles.searchContainer}>
+          <div className={styles.searchWrapper}>
             <Search className={styles.searchIcon} />
             <Input
               placeholder="Search your transactions..."
@@ -43,19 +54,37 @@ function TransactionsContent() {
           <ManualEntryModal />
         </div>
       </div>
-      <LineItemTableFilters />
-      <LineItemTable />
+      <div className={styles.reconciliationToggle}>
+        <Button
+          variant={reconciled ? "default" : "ghost"}
+          onClick={() => updateReconciled(true)}
+          className={styles.button}
+        >
+          Reconciled
+        </Button>
+        <Button
+          variant={reconciled ? "ghost" : "default"}
+          onClick={() => updateReconciled(false)}
+          className={styles.button}
+        >
+          Unreconciled
+        </Button>
+      </div>
+      {reconciled ? <ReconciledView /> : <UnreconciledView />}
     </div>
   );
 }
-
 const styles = {
   container:
     "p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)] flex-1",
   formTitle: "font-bold text-xl",
-  spacer: "mb-4 border border-black-100",
   searchIcon:
     "absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500",
   input:
     "pl-10 py-2 rounded-full bg-gray-100 border-none focus:ring-0 w-full shadow-sm",
+  reconciliationToggle: "flex space-x-4",
+  header: "flex items-center justify-between mb-4",
+  searchContainer: "flex space-x-8",
+  searchWrapper: "relative w-80",
+  button: "px-4 py-2 rounded-md",
 };

--- a/frontend/src/app/(main)/transactions/page.tsx
+++ b/frontend/src/app/(main)/transactions/page.tsx
@@ -22,7 +22,7 @@ export default function Transactions() {
 }
 
 function TransactionsContent() {
-  const [reconciled, setReconciled] = useState(false);
+  const [reconciled, setReconciled] = useState(true);
   const { filters, setFilters } = useLineItems();
   const { searchTerm, setSearchTerm, debouncedTerm } = useDebouncedSearch(
     filters.searchTerm

--- a/frontend/src/components/transactions/LineItemTable.tsx
+++ b/frontend/src/components/transactions/LineItemTable.tsx
@@ -41,7 +41,8 @@ export default function LineItemTable({
   const [sorting, setSorting] = useState<SortingState>([]);
   const { fetchData, pagination, setPagination } = useLineItems();
 
-  const [selectedRowData, setSelectedRowData] = useState<Row<LineItem> | null>(
+  // object and boolean to handle clicking a row's action button
+  const [clickedRowData, setClickedRowData] = useState<Row<LineItem> | null>(
     null
   );
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -62,12 +63,13 @@ export default function LineItemTable({
     },
   });
 
+  // boolean determining if any row is selected
   const rowIsSelected = table
     .getRowModel()
     .rows.some((row) => row.getIsSelected());
 
   const openEditDialog = (row: Row<LineItem>) => {
-    setSelectedRowData(row);
+    setClickedRowData(row);
     setIsDialogOpen(true);
   };
 
@@ -151,7 +153,6 @@ export default function LineItemTable({
           </TableBody>
         </Table>
       </div>
-
       {paginated && (
         <DataTablePagination
           table={table}
@@ -160,16 +161,15 @@ export default function LineItemTable({
         />
       )}
 
-      {selectedRowData && (
+      {clickedRowData && (
         <ModalDialog
-          selectedRowData={selectedRowData}
+          selectedRowData={clickedRowData}
           isDialogOpen={isDialogOpen}
           setIsDialogOpen={setIsDialogOpen}
           onReconcileSuccess={handleReconcileSuccess}
         />
       )}
 
-      <br />
       {rowIsSelected && <LineItemTableActions table={table} />}
     </>
   );

--- a/frontend/src/components/transactions/LineItemTable.tsx
+++ b/frontend/src/components/transactions/LineItemTable.tsx
@@ -77,8 +77,8 @@ export default function LineItemTable({
   };
 
   return (
-    <div>
-      <div className="rounded-md border">
+    <>
+      <div className="rounded-md  bg-white">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -171,6 +171,6 @@ export default function LineItemTable({
 
       <br />
       {rowIsSelected && <LineItemTableActions table={table} />}
-    </div>
+    </>
   );
 }

--- a/frontend/src/components/transactions/ReconciledView.tsx
+++ b/frontend/src/components/transactions/ReconciledView.tsx
@@ -43,7 +43,7 @@ const ScopeTablePreview = ({
   handleClick?: () => void;
 }) => {
   const filteredData = data.line_items
-    .filter((item) => item.scope === scope)
+    ?.filter((item) => item.scope === scope)
     .slice(0, 5);
 
   return (
@@ -66,7 +66,7 @@ const ScopeTablePreview = ({
       <LineItemTable
         columns={reconciledColumns}
         data={filteredData}
-        rowCount={filteredData.length}
+        rowCount={filteredData?.length}
         paginated={false}
       />
     </div>
@@ -82,7 +82,7 @@ const ScopeReconciledView = ({
   scope?: number;
   handleClick: () => void;
 }) => {
-  const filteredData = data.line_items.filter((item) => item.scope === scope);
+  const filteredData = data.line_items?.filter((item) => item.scope === scope);
 
   return (
     <div className="mt-4 mb-8">

--- a/frontend/src/components/transactions/ReconciledView.tsx
+++ b/frontend/src/components/transactions/ReconciledView.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { GetLineItemResponse } from "@/types";
+import { reconciledColumns } from "./columns";
+import { HelpCircle, ArrowRight } from "lucide-react";
+import LineItemTable from "./LineItemTable";
+import { useLineItems } from "@/context/LineItemsContext";
+
+const ReconciledView = () => {
+  const [seeScope, setSeeScope] = useState<number | undefined>();
+
+  const { data } = useLineItems();
+
+  return (
+    <div>
+      {!seeScope &&
+        [1, 2, 3].map((scope) => (
+          <ScopeTablePreview
+            key={scope}
+            data={data}
+            scope={scope}
+            handleClick={() => setSeeScope(scope)}
+          />
+        ))}
+
+      {seeScope && (
+        <ScopeReconciledView
+          data={data}
+          scope={seeScope}
+          handleClick={() => setSeeScope(undefined)}
+        />
+      )}
+    </div>
+  );
+};
+
+const ScopeTablePreview = ({
+  data,
+  scope,
+  handleClick,
+}: {
+  data: GetLineItemResponse;
+  scope?: number;
+  handleClick?: () => void;
+}) => {
+  const filteredData = data.line_items.filter((item) => item.scope === scope);
+  filteredData.slice(5);
+
+  return (
+    <div className="mt-4 mb-8">
+      {scope && (
+        <div className="flex justify-between ">
+          <div className="flex items-center space-x-2 mb-2">
+            <p className="font-bold text-lg">Scope {scope}</p>
+            <HelpCircle className="w-4" />
+          </div>
+          <div
+            className="flex items-center space-x-2 cursor-pointer"
+            onClick={handleClick}
+          >
+            <p className="text-sm">See all</p>
+            <ArrowRight className="w-4" />
+          </div>
+        </div>
+      )}
+      <LineItemTable
+        columns={reconciledColumns}
+        data={filteredData}
+        rowCount={filteredData.length}
+        paginated={false}
+      />
+    </div>
+  );
+};
+
+const ScopeReconciledView = ({
+  data,
+  scope,
+  handleClick,
+}: {
+  data: GetLineItemResponse;
+  scope?: number;
+  handleClick: () => void;
+}) => {
+  const filteredData = data.line_items.filter((item) => item.scope === scope);
+
+  return (
+    <div className="mt-4 mb-8">
+      <div className="flex justify-between">
+        <p className="font-bold text-lg mb-2">All Scope {scope} Transactions</p>
+        <p className="cursor-pointer" onClick={handleClick}>
+          See all scopes
+        </p>
+      </div>
+      <LineItemTable
+        columns={reconciledColumns}
+        data={filteredData}
+        rowCount={filteredData.length}
+      />
+    </div>
+  );
+};
+
+export default ReconciledView;

--- a/frontend/src/components/transactions/ReconciledView.tsx
+++ b/frontend/src/components/transactions/ReconciledView.tsx
@@ -42,8 +42,9 @@ const ScopeTablePreview = ({
   scope?: number;
   handleClick?: () => void;
 }) => {
-  const filteredData = data.line_items.filter((item) => item.scope === scope);
-  filteredData.slice(5);
+  const filteredData = data.line_items
+    .filter((item) => item.scope === scope)
+    .slice(0, 5);
 
   return (
     <div className="mt-4 mb-8">

--- a/frontend/src/components/transactions/UnreconciledView.tsx
+++ b/frontend/src/components/transactions/UnreconciledView.tsx
@@ -1,4 +1,3 @@
-import { GetLineItemResponse } from "@/types";
 import React from "react";
 import LineItemTable from "./LineItemTable";
 import LineItemTableFilters from "./LineItemTableFilters";

--- a/frontend/src/components/transactions/UnreconciledView.tsx
+++ b/frontend/src/components/transactions/UnreconciledView.tsx
@@ -1,0 +1,23 @@
+import { GetLineItemResponse } from "@/types";
+import React from "react";
+import LineItemTable from "./LineItemTable";
+import LineItemTableFilters from "./LineItemTableFilters";
+import { unreconciledColumns } from "./columns";
+import { useLineItems } from "@/context/LineItemsContext";
+
+const UnreconciledView = () => {
+  const { data } = useLineItems();
+  console.log("cols: ", unreconciledColumns);
+  return (
+    <div>
+      <LineItemTableFilters />
+      <LineItemTable
+        columns={unreconciledColumns}
+        data={data.line_items}
+        rowCount={data.total}
+      />
+    </div>
+  );
+};
+
+export default UnreconciledView;

--- a/frontend/src/components/transactions/UnreconciledView.tsx
+++ b/frontend/src/components/transactions/UnreconciledView.tsx
@@ -6,7 +6,7 @@ import { useLineItems } from "@/context/LineItemsContext";
 
 const UnreconciledView = () => {
   const { data } = useLineItems();
-  console.log("cols: ", unreconciledColumns);
+
   return (
     <div>
       <LineItemTableFilters />

--- a/frontend/src/components/transactions/columns.tsx
+++ b/frontend/src/components/transactions/columns.tsx
@@ -1,94 +1,112 @@
-"use client";
-
-import { Checkbox } from "@/components/ui/checkbox";
-import { ColumnHeader } from "@/components/ui/columnHeader";
 import { LineItem } from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
+import { ColumnHeader } from "../ui/columnHeader";
+import { Checkbox } from "@radix-ui/react-checkbox";
 
-export const columns: ColumnDef<LineItem>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        className="ml-2"
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-      />
-    ),
-  },
-  {
-    accessorKey: "date",
-    header: ({ column }) => {
-      return <ColumnHeader name="Date" column={column} />;
-    },
-    cell: ({ row }) => {
-      const date = new Date(row.getValue("date"));
-      const formattedDate = date.getMonth() + 1 + "/" + date.getDate();
-      return <div className="font-medium">{formattedDate}</div>;
-    },
-  },
-  {
-    accessorKey: "description",
-    header: ({ column }) => {
-      return <ColumnHeader name="Name" column={column} />;
-    },
-  },
+const selectColumn: ColumnDef<LineItem> = {
+  id: "select",
+  header: ({ table }) => (
+    <Checkbox
+      className="ml-2"
+      checked={
+        table.getIsAllPageRowsSelected() ||
+        (table.getIsSomePageRowsSelected() && "indeterminate")
+      }
+      onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+      aria-label="Select all"
+    />
+  ),
+  cell: ({ row }) => (
+    <Checkbox
+      className="border border-purple-700"
+      checked={row.getIsSelected()}
+      onCheckedChange={(value) => row.toggleSelected(!!value)}
+      aria-label="Select row"
+    />
+  ),
+  size: 25,
+};
 
-  {
-    accessorKey: "emission_factor_name",
-    header: ({ column }) => {
-      return <ColumnHeader name="Emissions Factor" column={column} />;
-    },
+const dateColumn: ColumnDef<LineItem> = {
+  accessorKey: "date",
+  header: ({ column }) => {
+    return <ColumnHeader name="Date" column={column} />;
   },
-
-  {
-    accessorKey: "contact_name",
-    header: ({ column }) => {
-      return <ColumnHeader name="Contact" column={column} />;
-    },
+  cell: ({ row }) => {
+    const date = new Date(row.getValue("date"));
+    const formattedDate = date.getMonth() + 1 + "/" + date.getDate();
+    return <div className="font-medium">{formattedDate}</div>;
   },
+  size: 75,
+};
 
-  {
-    accessorKey: "co2",
-    header: ({ column }) => {
-      return (
-        <ColumnHeader name="CO2" column={column} />
-      );
-    },
-    cell: ({ row }) => {
-      const co2 = parseFloat(row.getValue("co2"));
-      const formatted = !Number.isNaN(co2) ? `${co2} kg` : "";
-
-      return <div className="font-medium">{formatted}</div>;
-    },
+const descriptionColumn: ColumnDef<LineItem> = {
+  accessorKey: "description",
+  header: ({ column }) => {
+    return <ColumnHeader name="Description" column={column} />;
   },
+  size: 200,
+};
 
-  {
-    accessorKey: "total_amount",
-    header: ({ column }) => {
-      return (
-        <ColumnHeader name="Amount" column={column} className="text-right" />
-      );
-    },
-    cell: ({ row }) => {
-      const amount = parseFloat(row.getValue("total_amount"));
-      const formatted = new Intl.NumberFormat("en-US", {
-        style: "currency",
-        currency: "USD",
-      }).format(amount);
-
-      return <div className="text-right font-medium pr-4">{formatted}</div>;
-    },
+const emissionFactorColumn: ColumnDef<LineItem> = {
+  accessorKey: "emission_factor_name",
+  header: ({ column }) => {
+    return <ColumnHeader name="Emissions Factor" column={column} />;
   },
+  size: 200,
+};
+
+const contactColumn: ColumnDef<LineItem> = {
+  accessorKey: "contact_name",
+  header: ({ column }) => {
+    return <ColumnHeader name="Contact" column={column} />;
+  },
+  size: 150,
+};
+const co2Column: ColumnDef<LineItem> = {
+  accessorKey: "co2",
+  header: ({ column }) => {
+    return <ColumnHeader name="CO2" column={column} />;
+  },
+  cell: ({ row }) => {
+    const co2 = parseFloat(row.getValue("co2"));
+    const formatted = !Number.isNaN(co2) ? `${co2} kg` : "";
+
+    return <div className="font-medium">{formatted}</div>;
+  },
+  size: 75,
+};
+const amountColumn: ColumnDef<LineItem> = {
+  accessorKey: "total_amount",
+  header: ({ column }) => {
+    return (
+      <ColumnHeader name="Amount" column={column} className="text-right" />
+    );
+  },
+  cell: ({ row }) => {
+    const amount = parseFloat(row.getValue("total_amount"));
+    const formatted = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(amount);
+
+    return <div className="text-right font-medium pr-4">{formatted}</div>;
+  },
+  size: 80,
+};
+
+export const unreconciledColumns: ColumnDef<LineItem>[] = [
+  selectColumn,
+  dateColumn,
+  descriptionColumn,
+  contactColumn,
+  amountColumn,
+];
+export const reconciledColumns: ColumnDef<LineItem>[] = [
+  dateColumn,
+  descriptionColumn,
+  emissionFactorColumn,
+  co2Column,
+  contactColumn,
+  amountColumn,
 ];

--- a/frontend/src/components/transactions/columns.tsx
+++ b/frontend/src/components/transactions/columns.tsx
@@ -1,7 +1,7 @@
 import { LineItem } from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
 import { ColumnHeader } from "../ui/columnHeader";
-import { Checkbox } from "@radix-ui/react-checkbox";
+import { Checkbox } from "@/components/ui/checkbox";
 
 const selectColumn: ColumnDef<LineItem> = {
   id: "select",
@@ -18,7 +18,6 @@ const selectColumn: ColumnDef<LineItem> = {
   ),
   cell: ({ row }) => (
     <Checkbox
-      className="border border-purple-700"
       checked={row.getIsSelected()}
       onCheckedChange={(value) => row.toggleSelected(!!value)}
       aria-label="Select row"

--- a/frontend/src/components/ui/DataTablePagination.tsx
+++ b/frontend/src/components/ui/DataTablePagination.tsx
@@ -26,7 +26,7 @@ export function DataTablePagination<TData>({
   total_count,
 }: DataTablePaginationProps<TData>) {
   return (
-    <div className="flex items-center justify-end px-2">
+    <div className="flex items-center justify-end px-2 mt-4">
       <div className="flex items-center space-x-6 lg:space-x-8">
         <div className="flex items-center space-x-2">
           <p className="text-sm font-medium">Rows per page</p>

--- a/frontend/src/components/ui/columnHeader.tsx
+++ b/frontend/src/components/ui/columnHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Column } from "@tanstack/react-table";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { Button } from "./button";
-import Image from "next/image";
 
 type ColumnHeaderProps<T extends object> = {
   column: Column<T>;
@@ -9,11 +9,11 @@ type ColumnHeaderProps<T extends object> = {
   className?: string;
 };
 
-function SortIcon() {
-  return <Image src={"sort.svg"} width={20} height={20} alt="Sort column" />;
-}
-
-const ColumnHeader = <T extends object>({ column, name, className }: ColumnHeaderProps<T>) => {
+const ColumnHeader = <T extends object>({
+  column,
+  name,
+  className,
+}: ColumnHeaderProps<T>) => {
   return (
     <div className={className}>
       <Button
@@ -22,10 +22,9 @@ const ColumnHeader = <T extends object>({ column, name, className }: ColumnHeade
         onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
       >
         {name}
-        <SortIcon />
+        {column.getIsSorted() == "asc" ? <ChevronUp /> : <ChevronDown />}
       </Button>
     </div>
   );
 };
-
 export { ColumnHeader };

--- a/frontend/src/services/lineItems.ts
+++ b/frontend/src/services/lineItems.ts
@@ -24,6 +24,9 @@ function buildQueryParams(filters: LineItemFilters) {
   if (filters?.maxPrice) {
     params.max_price = filters.maxPrice?.toString();
   }
+  if (filters?.reconciled != undefined) {
+    params.reconciliation_status = filters.reconciled.toString();
+  }
   if (filters?.searchTerm) {
     params.search_term = filters.searchTerm;
   }
@@ -44,9 +47,8 @@ function buildQueryParams(filters: LineItemFilters) {
 }
 
 export async function fetchLineItems(
-  filters: LineItemFilters,
+  filters: LineItemFilters
 ): Promise<GetLineItemResponse> {
-
   try {
     const response = await apiClient.get("/line-item", {
       params: buildQueryParams(filters),
@@ -62,7 +64,6 @@ export async function createLineItem(
   item: CreateLineItemRequest,
   companyId: string
 ): Promise<void> {
-  
   const new_item = {
     description: item.description,
     total_amount: item.total_amount,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,8 +14,8 @@ export type LineItem = {
 export type GetLineItemResponse = {
   count: number;
   total: number;
-  line_items: LineItem[]
-}
+  line_items: LineItem[];
+};
 
 export interface LineItemFilters {
   dates?: DateRange;
@@ -27,6 +27,7 @@ export interface LineItemFilters {
   contact_id?: string;
   pageSize?: number;
   pageIndex?: number;
+  reconciled?: boolean;
 }
 
 export type CreateLineItemRequest = {
@@ -58,7 +59,7 @@ export type ReconcileRequest = {
   scope?: number;
   emissionsFactorId?: string;
   contactId?: string;
-}
+};
 
 export type EmissionsFactor = {
   name: string;
@@ -68,7 +69,7 @@ export type EmissionsFactor = {
 export type Price = {
   minPrice: number;
   maxPrice: number;
-}
+};
 
 export type EmissionsFactorCategory = {
   name: string;
@@ -97,7 +98,7 @@ export type GetContactsResponse = {
   total: number;
   count: number;
   contacts: Contact[];
-}
+};
 
 export type CreateContactRequest = {
   name: string;
@@ -112,41 +113,41 @@ export type ContactEmissions = {
   contact_id: string;
   contact_name: string;
   carbon: number;
-}
+};
 
 export type ContactTreeEmissions = {
   contact_emissions: ContactEmissions;
   start_date: Date;
   end_date: Date;
-}
+};
 
 export type GetGrossEmissionsRequest = {
   company_id: string;
   start_date: Date;
   end_date: Date;
-}
+};
 
 export type ScopeSummary = {
   scope_one: number;
   scope_two: number;
   scope_three: number;
-}
+};
 
 export type MonthSummary = {
   month_start: Date;
   scopes: ScopeSummary;
-}
+};
 
 export type GrossSummary = {
   total_co2: number;
   start_date: Date;
   end_date: Date;
   months: MonthSummary[];
-}
+};
 
 export type GetContactEmissionsRequest = {
   company_id: string;
   contact_id: string;
   start_date: Date;
   end_date: Date;
-}
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the transaction page to reflect the flow in the Figma, where transactions are split according to their reconciliation status. The table columns for each screen are slightly different, so those have been modified. Also, filters are only shown for unreconciled line items, and the toolbar is only shown when unreconciled rows are selected in the table.

Reconciled transactions are further split by their scope.

NOTE:
This is currently a naive approach just to get the flow and components to be functional. It works by updating the line item filters in context, triggering a new backend call every time the toggle is switched. It makes the data loading look a little choppy which is not great but we will fix it!

I plan to update these obnoxious fetches with something smarter in a follow up PR, but for now want to keep this PR medium-sized and let the design team and anyone else test out the new page flow. More importantly, it buys me time because I'm struggling to rework our context architecture 🤯


## How Has This Been Tested?

#### Frontend PRs
Page route (and description of to get to this flow if necessary):

Screenshots/screen recording:
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/0273ba9d-e290-4a88-a728-e91be627fa93" />
<img width="1173" alt="image" src="https://github.com/user-attachments/assets/7831e6b6-71cc-4d5c-8e40-cd611a7b7dc6" />
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/4d12ddd4-db47-4409-9079-89ffbd52f26c" />


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
