### PR TITLE
Allow users to mark line items as offsets

### DIFF
--- a/frontend/src/components/transactions/LineItemTableActions.tsx
+++ b/frontend/src/components/transactions/LineItemTableActions.tsx
@@ -9,24 +9,57 @@ import {
 } from "../ui/select";
 import { Button } from "../ui/button";
 import EmissionsFactorSelector from "./CategorySelector";
-import { EmissionsFactor, ReconcileBatchRequest } from "@/types";
+import { Input } from "../ui/input";
+import {
+  BatchCreateCarbonOffsetsRequest,
+  EmissionsFactor,
+  LineItem,
+  ReconcileBatchRequest,
+} from "@/types";
 import { useLineItems } from "@/context/LineItemsContext";
-import { reconcileBatch } from "@/services/lineItems";
+import { reconcileBatch, reconcileBatchOffset } from "@/services/lineItems";
+import { useAuth } from "@/context/AuthContext";
 
-type LineItemTableActionsProps<LineItem> = {
+type LineItemTableActionsProps = {
   table: Table<LineItem>;
 };
 
-export function LineItemTableActions<LineItem>({
-  table,
-}: LineItemTableActionsProps<LineItem>) {
+export function LineItemTableActions({ table }: LineItemTableActionsProps) {
   const [scope, setScope] = useState("");
   const [emissionsFactor, setEmissionsFactor] = useState<EmissionsFactor>();
-
+  const [carbon, setCarbon] = useState(0);
+  const { companyId } = useAuth();
   const { fetchData } = useLineItems();
 
-  async function reconcileItems() {
+  async function handleReconciliation() {
+    if (scope === "0") {
+      await handleCarbonOffsetReconciliation();
+    } else {
+      await handleLineItemReconciliation();
+    }
+
+    resetState();
+    fetchData();
+  }
+
+  // Handles reconciliation for carbon offsets
+  async function handleCarbonOffsetReconciliation() {
+    const request: BatchCreateCarbonOffsetsRequest = {
+      carbon_offsets: table.getSelectedRowModel().rows.map((row) => ({
+        carbon_amount_kg: carbon,
+        company_id: companyId ?? "",
+        source: row.original.id,
+        purchase_date: row.original.date,
+      })),
+    };
+
+    await reconcileBatchOffset(request);
+  }
+
+  // Handles reconciliation for regular line items
+  async function handleLineItemReconciliation() {
     const selectedIds = table.getSelectedRowModel().rows.map((row) => row.id);
+
     const request: ReconcileBatchRequest = {
       lineItemIds: selectedIds,
       ...(scope && { scope: Number(scope) }),
@@ -36,30 +69,67 @@ export function LineItemTableActions<LineItem>({
     };
 
     await reconcileBatch(request);
+  }
+
+  function resetState() {
     table.resetRowSelection();
     setScope("");
     setEmissionsFactor(undefined);
-    fetchData();
+    setCarbon(0);
   }
 
   return (
-    <div className="flex w-full space-x-2 px-2 py-2">
+    <div className="flex w-full items-end space-x-2 px-2 py-2">
+      <ScopeSelector setScope={setScope} />
+      {scope !== "0" ? (
+        <EmissionsFactorSelector
+          emissionsFactor={emissionsFactor}
+          setEmissionsFactor={setEmissionsFactor}
+        />
+      ) : (
+        <CarbonOffsetInput carbon={carbon} setCarbon={setCarbon} />
+      )}
+      <Button onClick={handleReconciliation}>Reconcile</Button>
+    </div>
+  );
+}
+
+function ScopeSelector({ setScope }: { setScope: (value: string) => void }) {
+  return (
+    <div>
+      <label className="text-sm font-medium w-full">Scope</label>
       <Select onValueChange={(value) => setScope(value)}>
-        <SelectTrigger className="w-[180px]">
+        <SelectTrigger className="w-[180px] bg-white">
           <SelectValue placeholder="Select scope" />
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="1">Scope 1</SelectItem>
           <SelectItem value="2">Scope 2</SelectItem>
           <SelectItem value="3">Scope 3</SelectItem>
+          <SelectItem value="0">Offset</SelectItem>
         </SelectContent>
       </Select>
+    </div>
+  );
+}
 
-      <EmissionsFactorSelector
-        emissionsFactor={emissionsFactor}
-        setEmissionsFactor={setEmissionsFactor}
+function CarbonOffsetInput({
+  carbon,
+  setCarbon,
+}: {
+  carbon: number;
+  setCarbon: (value: number) => void;
+}) {
+  return (
+    <div className="flex flex-col items-center">
+      <label className="text-sm font-medium w-full">Carbon offset (kg)</label>
+      <Input
+        type="number"
+        className="bg-white"
+        value={carbon ?? ""}
+        onChange={(e) => setCarbon(parseFloat(e.target.value))}
+        placeholder="10 kg"
       />
-      <Button onClick={reconcileItems}>Reconcile</Button>
     </div>
   );
 }

--- a/frontend/src/components/transactions/LineItemTableActions.tsx
+++ b/frontend/src/components/transactions/LineItemTableActions.tsx
@@ -48,7 +48,7 @@ export function LineItemTableActions({ table }: LineItemTableActionsProps) {
       carbon_offsets: table.getSelectedRowModel().rows.map((row) => ({
         carbon_amount_kg: carbon,
         company_id: companyId ?? "",
-        source: row.original.id,
+        source: row.original.description,
         purchase_date: row.original.date,
       })),
     };

--- a/frontend/src/components/transactions/LineItemTableActions.tsx
+++ b/frontend/src/components/transactions/LineItemTableActions.tsx
@@ -27,12 +27,16 @@ type LineItemTableActionsProps = {
 export function LineItemTableActions({ table }: LineItemTableActionsProps) {
   const [scope, setScope] = useState("");
   const [emissionsFactor, setEmissionsFactor] = useState<EmissionsFactor>();
-  const [carbon, setCarbon] = useState(0);
+  const [carbon, setCarbon] = useState<number>();
   const { companyId } = useAuth();
   const { fetchData } = useLineItems();
 
   async function handleReconciliation() {
     if (scope === "0") {
+      if (!carbon || carbon <= 0) {
+        alert("Please enter a valid carbon offset amount.");
+        return;
+      }
       await handleCarbonOffsetReconciliation();
     } else {
       await handleLineItemReconciliation();
@@ -46,7 +50,7 @@ export function LineItemTableActions({ table }: LineItemTableActionsProps) {
   async function handleCarbonOffsetReconciliation() {
     const request: BatchCreateCarbonOffsetsRequest = {
       carbon_offsets: table.getSelectedRowModel().rows.map((row) => ({
-        carbon_amount_kg: carbon,
+        carbon_amount_kg: carbon ?? 0,
         company_id: companyId ?? "",
         source: row.original.description,
         purchase_date: row.original.date,
@@ -117,7 +121,7 @@ function CarbonOffsetInput({
   carbon,
   setCarbon,
 }: {
-  carbon: number;
+  carbon: number | undefined;
   setCarbon: (value: number) => void;
 }) {
   return (
@@ -126,9 +130,10 @@ function CarbonOffsetInput({
       <Input
         type="number"
         className="bg-white"
-        value={carbon ?? ""}
+        value={carbon ?? "0"}
         onChange={(e) => setCarbon(parseFloat(e.target.value))}
         placeholder="10 kg"
+        min="0"
       />
     </div>
   );

--- a/frontend/src/services/lineItems.ts
+++ b/frontend/src/services/lineItems.ts
@@ -1,4 +1,5 @@
 import {
+  BatchCreateCarbonOffsetsRequest,
   CreateLineItemRequest,
   GetLineItemResponse,
   LineItemFilters,
@@ -90,6 +91,16 @@ export async function reconcileBatch(request: ReconcileBatchRequest) {
       scope: request.scope,
       emissions_factor_id: request.emissionsFactorId,
     });
+  } catch (error) {
+    console.error("Error updating dashboard items", error);
+  }
+}
+
+export async function reconcileBatchOffset(
+  request: BatchCreateCarbonOffsetsRequest
+) {
+  try {
+    await apiClient.post("/carbon-offset/batch", request);
   } catch (error) {
     console.error("Error updating dashboard items", error);
   }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,6 +9,7 @@ export type LineItem = {
   scope?: number;
   contact_name?: string;
   co2?: number;
+  date: Date;
 };
 
 export type GetLineItemResponse = {
@@ -159,4 +160,23 @@ export type GetContactEmissionsRequest = {
   contact_id: string;
   start_date: Date;
   end_date: Date;
+};
+
+export type CarbonOffset = {
+  id: number;
+  carbon_amount_kg: number;
+  company_id: string;
+  source: string;
+  purchase_date: Date;
+};
+
+export type CreateCarbonOffsetRequest = {
+  carbon_amount_kg: number;
+  company_id: string;
+  source: string;
+  purchase_date: Date;
+};
+
+export type BatchCreateCarbonOffsetsRequest = {
+  carbon_offsets: CreateCarbonOffsetRequest[];
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

this adds frontend support for our reconciling offsets feature.



Open question: Since these come in as line_items and are in our line_item table, what should we do with them after adding them to the carbon_offset table? (currently, they just sit there which means they will always sit in the unreconciled pile.)
Options:
   - keep line-item record since it contains the xero_line_item_id and contact_id and $ amount, but somehow mark it as an offset (maybe we add an offset_id column where null implies it's not an offset and a value implies that it is)
   -  delete from line-item table

I kind of want to do the first option just in case we need the other data but idk if that's unnecessary

 

<!--- Describe your changes at a high-level -->


## How Has This Been Tested?

#### Backend PRs
<!--- Please include a URL for the success case. Treat this as a reference for future developers - people should be able to use this to successfully use your endpoint later on! -->
Postman URL here:

Body parameters (if required):

Postman/Supabase screenshots:

#### Frontend PRs
Page route (and description of to get to this flow if necessary):

Screenshots/screen recording:

https://github.com/user-attachments/assets/4bd3f4f7-a701-4422-bced-a764d7575d87



## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
