### PR TITLE
Foreign key relationship between public.line_item and public.carbon_offset, added public.carbon_offset.line_item_id column

### DIFF
--- a/backend/internal/storage/postgres/storage.go
+++ b/backend/internal/storage/postgres/storage.go
@@ -12,8 +12,8 @@ import (
 
 // Establishes a sustained connection to the PostgreSQL database using pooling.
 func ConnectDatabase(ctx context.Context, config config.DB) (*pgxpool.Pool, error) {
-	// dbConfig, err := pgxpool.ParseConfig(config.Connection())
-	dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@host.docker.internal:54322/postgres")
+	dbConfig, err := pgxpool.ParseConfig(config.Connection())
+	// dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@host.docker.internal:54322/postgres")
 	if err != nil {
 		log.Fatalf("Failed to connect to the database: %v", err)
 		return nil, err

--- a/backend/internal/storage/postgres/storage.go
+++ b/backend/internal/storage/postgres/storage.go
@@ -12,9 +12,8 @@ import (
 
 // Establishes a sustained connection to the PostgreSQL database using pooling.
 func ConnectDatabase(ctx context.Context, config config.DB) (*pgxpool.Pool, error) {
-	dbConfig, err := pgxpool.ParseConfig(config.Connection())
-	// dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@host.docker.internal:54322/postgres")
-	// dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@127.0.0.1:54322/postgres")
+	// dbConfig, err := pgxpool.ParseConfig(config.Connection())
+	dbConfig, err := pgxpool.ParseConfig("postgresql://postgres:postgres@host.docker.internal:54322/postgres")
 	if err != nil {
 		log.Fatalf("Failed to connect to the database: %v", err)
 		return nil, err

--- a/backend/internal/supabase/migrations/20250329183649_carbon_offset_line_item_relationship.sql
+++ b/backend/internal/supabase/migrations/20250329183649_carbon_offset_line_item_relationship.sql
@@ -1,0 +1,6 @@
+ALTER TABLE carbon_offset ADD COLUMN line_item_id UUID;
+
+ALTER TABLE carbon_offset
+ADD CONSTRAINT fk_carbon_offset_line_item
+FOREIGN KEY (line_item_id) 
+REFERENCES line_item(id);


### PR DESCRIPTION
Made a migration script for altering the carbon_offset table in the public schema for creating a line_item_id column to link offsets with their corresponding line_items, retaining the semantics that an offset does can either come from Xero (with a line_item_id) or manually entered (without a line_item_id). 

## Description

[Link to Ticket](https://github.com/GenerateNU/arenius/issues/161)

## How Has This Been Tested?
Locally with Supabase:

![image](https://github.com/user-attachments/assets/152b1966-9aa2-4ca0-9f7b-77cf71d2576f)

## Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
