### PR TITLE
paginate contacts table on the frontend

### DIFF
--- a/frontend/src/components/contacts/ContactTable.tsx
+++ b/frontend/src/components/contacts/ContactTable.tsx
@@ -7,6 +7,7 @@ import {
   SortingState,
   useReactTable,
   getSortedRowModel,
+  getPaginationRowModel,
 } from "@tanstack/react-table";
 import {
   Table,
@@ -24,16 +25,16 @@ import { useRouter } from "next/navigation"; // Use useRouter here
 
 export default function ContactTable() {
   const [sorting, setSorting] = useState<SortingState>([]);
-  const { data, pagination, setPagination } = useContacts();
+  const { data } = useContacts();
   const router = useRouter(); // Get router here
 
   const table = useReactTable({
     data: data.contacts || [],
     columns: columns(router), // Pass router as a prop to columns
     getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
-    manualPagination: true,
     rowCount: data.total,
     getRowId: (row: Contact) => row.id,
     state: {
@@ -94,15 +95,11 @@ export default function ContactTable() {
         </Table>
       </div>
       <DataTablePagination
-        page={pagination.pageIndex}
-        pageLimit={pagination.pageSize}
-        total_count={data.total}
-        setPage={(newPage) =>
-          setPagination({ ...pagination, pageIndex: newPage })
-        }
-        setPageLimit={(newLimit) =>
-          setPagination({ ...pagination, pageSize: newLimit })
-        }
+        page={table.getState().pagination.pageIndex}
+        pageLimit={table.getState().pagination.pageSize}
+        total_count={data.contacts?.length}
+        setPage={(newPage) => table.setPageIndex(newPage)}
+        setPageLimit={(newLimit) => table.setPageSize(newLimit)}
       />
       <br />
     </>

--- a/frontend/src/components/transactions/ContactsSelector.tsx
+++ b/frontend/src/components/transactions/ContactsSelector.tsx
@@ -40,7 +40,7 @@ export default function ContactSelector({
           <ChevronDown className="ml-2" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-80">
+      <DropdownMenuContent className="w-80 max-h-96 overflow-y-auto">
         {contactResponse?.contacts && contactResponse?.contacts.length > 0 ? (
           contactResponse.contacts.map((c) => (
             <DropdownMenuItem key={c.id} onClick={() => setContact(c)}>

--- a/frontend/src/context/ContactContext.tsx
+++ b/frontend/src/context/ContactContext.tsx
@@ -7,7 +7,6 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
-import { PaginationState } from "@tanstack/react-table";
 
 import { useAuth } from "@/context/AuthContext";
 import { fetchContacts } from "@/services/contacts";
@@ -37,7 +36,7 @@ export const ContactProvider: React.FC<{ children: React.ReactNode }> = ({
   const [filters, setFilters] = useState<GetContactsRequest>(
     {} as GetContactsRequest
   );
-  const { companyId, tenantId, isLoading } = useAuth();
+  const { companyId, isLoading } = useAuth();
 
   const fetchData = useCallback(async () => {
     if (isLoading) {
@@ -60,7 +59,7 @@ export const ContactProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       console.error("Error fetching contacts:", error);
     }
-  }, [filters, companyId, tenantId, isLoading]);
+  }, [filters, companyId, isLoading]);
 
   useEffect(() => {
     if (!isLoading && companyId) {

--- a/frontend/src/context/ContactContext.tsx
+++ b/frontend/src/context/ContactContext.tsx
@@ -22,8 +22,6 @@ interface ContactContextValue {
       | GetContactsRequest
       | ((prevFilters: GetContactsRequest) => GetContactsRequest)
   ) => void;
-  pagination: PaginationState;
-  setPagination: React.Dispatch<React.SetStateAction<PaginationState>>;
 }
 
 const ContactContext = createContext<ContactContextValue | undefined>(
@@ -39,10 +37,6 @@ export const ContactProvider: React.FC<{ children: React.ReactNode }> = ({
   const [filters, setFilters] = useState<GetContactsRequest>(
     {} as GetContactsRequest
   );
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
-    pageSize: 10,
-  });
   const { companyId, tenantId, isLoading } = useAuth();
 
   const fetchData = useCallback(async () => {
@@ -60,20 +54,19 @@ export const ContactProvider: React.FC<{ children: React.ReactNode }> = ({
       console.log("Fetching contacts...");
       const result = await fetchContacts({
         ...filters,
-        ...pagination,
         company_id: companyId,
       });
       setData(result);
     } catch (error) {
       console.error("Error fetching contacts:", error);
     }
-  }, [filters, pagination, companyId, tenantId, isLoading]);
+  }, [filters, companyId, tenantId, isLoading]);
 
   useEffect(() => {
     if (!isLoading && companyId) {
       fetchData();
     }
-  }, [companyId, fetchData, filters, isLoading, pagination]);
+  }, [companyId, fetchData, filters, isLoading]);
 
   if (isLoading) {
     return <div>Loading...</div>;
@@ -86,8 +79,6 @@ export const ContactProvider: React.FC<{ children: React.ReactNode }> = ({
         fetchData,
         filters,
         setFilters,
-        pagination,
-        setPagination,
       }}
     >
       {children}

--- a/frontend/src/services/contacts.ts
+++ b/frontend/src/services/contacts.ts
@@ -25,7 +25,7 @@ export async function createContact(
 }
 
 function buildQueryParams(filters: GetContactsRequest) {
-  const params: Record<string, string | number | undefined> = {};
+  const params: Record<string, string | number | boolean | undefined> = {};
 
   if (filters?.search_term) {
     params.search_term = filters.search_term;
@@ -37,6 +37,8 @@ function buildQueryParams(filters: GetContactsRequest) {
     params.limit = filters.pageSize;
   }
 
+  params.unpaginated = true;
+
   return params;
 }
 
@@ -44,11 +46,9 @@ export async function fetchContacts(
   req: GetContactsRequest
 ): Promise<GetContactsResponse> {
   try {
-    console.log("fetchContacts:");
     const response = await apiClient.get(`/contact/company/${req.company_id}`, {
       params: buildQueryParams(req),
     });
-    console.log("Response from fetchContacts:", response.data);
     return response.data;
   } catch (error) {
     console.error("Error fetching contacts", error);


### PR DESCRIPTION
paginates contacts on the frontend by letting the shadcn table do the heavy lifting. this also fixes the contacts dropdown so that all contacts are shown instead of just the first page.