### PR TITLE
skeleton for top emission factors

### DIFF
--- a/frontend/src/components/dashboard/TopEmissions.tsx
+++ b/frontend/src/components/dashboard/TopEmissions.tsx
@@ -78,9 +78,24 @@ export default function TopEmissionsFactors() {
             </div>
           ))
         ) : (
-          <div className="flex h-32 items-center justify-center">
-            <p className="text-gray-500">No emissions data available</p>
-          </div>
+          [1, 2, 3, 4, 5].map((index) => (
+            <div
+              key={"skeleton" + index}
+              className={`flex justify-between items-center px-4 py-2 rounded-lg ${
+                index % 2 === 0 ? "bg-green-50" : "bg-white"
+              }`}
+            >
+              <div className="flex items-center w-2/3 py-5">
+                <div className="pr-6">
+                  <div className="h-6 w-6 bg-gray-200 rounded animate-pulse"></div>
+                </div>
+                <div>
+                  <div className="h-5 w-24 bg-gray-200 rounded animate-pulse"></div>
+                </div>
+              </div>
+              <div className="h-5 w-20 ml-auto bg-gray-200 rounded animate-pulse w-1/3 justify-end"></div>
+            </div>
+          ))
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[Link to Ticket](https://github.com/GenerateNU/arenius/issues/235)

<!--- Describe your changes at a high-level -->

When the emissions data isn't available or is zero, it now shows the pulsing animation loading thing. I tried to get the heights to match up but I'm not sure if I got it right - I don't know if it is something on my local or not, but the top emissions table was pretty tall yesterday and today it seems short again (most of the time)? This could be a separate bug or something but just lmk what we settled on so I can update the skeleton to match


## How Has This Been Tested?

#### Backend PRs
<!--- Please include a URL for the success case. Treat this as a reference for future developers - people should be able to use this to successfully use your endpoint later on! -->
Postman URL here:

Body parameters (if required):

Postman/Supabase screenshots:

#### Frontend PRs
Page route (and description of to get to this flow if necessary):

Screenshots/screen recording:
![Screenshot 2025-04-09 185207](https://github.com/user-attachments/assets/5b8337dd-7037-47d1-a669-3c91e7d11aa2)



## Checklist:
- [x] I have performed a self-review of my code
- [x] I have included either a Postman URL for my endpoint(s), and/or screenshots of the frontend
